### PR TITLE
Handle nil str in REGEX_MAP procs.

### DIFF
--- a/lib/browser_sniffer/patterns.rb
+++ b/lib/browser_sniffer/patterns.rb
@@ -136,7 +136,7 @@ class BrowserSniffer
         /(htc)[;_\s-]+([\w\s_]+(?=\))|\w+)*/i, # HTC
         /(zte)-(\w+)*/i, # ZTE
         /(alcatel|geeksphone|huawei|lenovo|nexian|panasonic|(?=;\s)sony)[_\s-]?([\w-]+)*/i # Alcatel/GeeksPhone/Huawei/Lenovo/Nexian/Panasonic/Sony
-      ], [:vendor, [:model, lambda {|str| str.gsub(/_/, ' ') }], [:type, :handheld]], [
+      ], [:vendor, [:model, lambda {|str| str && str.gsub(/_/, ' ') }], [:type, :handheld]], [
         /\s((milestone|droid[2x]?))[globa\s]*\sbuild\//i, # Motorola
         /(mot)[\s-]?(\w+)*/i
       ], [[:vendor, 'Motorola'], :model, [:type, :handheld]], [
@@ -226,9 +226,9 @@ class BrowserSniffer
         /\s([frentopc-]{0,4}bsd|dragonfly)\s?([\w\.]+)*/i # FreeBSD/NetBSD/OpenBSD/PC-BSD/DragonFly
       ], [:name, :version],[
         /(ip[honead]+)(?:.*os\s*([\w]+)*\slike\smac|;\sopera)/i # iOS
-      ], [[:name, 'iOS'], [:version, lambda {|str| str.gsub(/_/, '.') }], [:type, :ios]], [
+      ], [[:name, 'iOS'], [:version, lambda {|str| str && str.gsub(/_/, '.') }], [:type, :ios]], [
         /(mac\sos\sx)\s?([\w\s\.]+\w)*/i # Mac OS
-      ], [:name, [:version, lambda {|str| str.gsub(/_/, '.') }], [:type, :mac]], [
+      ], [:name, [:version, lambda {|str| str && str.gsub(/_/, '.') }], [:type, :mac]], [
         # Other
         /(haiku)\s(\w+)/i, # Haiku
         /(aix)\s((\d)(?=\.|\)|\s)[\w\.]*)*/i, # AIX

--- a/test/browser_sniffer_test.rb
+++ b/test/browser_sniffer_test.rb
@@ -391,6 +391,19 @@ class BrowserSnifferTest < MiniTest::Unit::TestCase
       :os_version => '5.0',
       :browser => :safari,
       :major_browser_version => 5
+    },
+    :excel_mac => {
+      :user_agent => "Mozilla/5.0 (Macintosh; Intel Mac OS X) Excel/14.34.0",
+      :form_factor => :desktop,
+      :ios? => false,
+      :android? => false,
+      :desktop? => true,
+      :engine => nil,
+      :major_engine_version => nil,
+      :os => :mac,
+      :os_version => nil,
+      :browser => nil,
+      :major_browser_version => nil
     }
   }
 


### PR DESCRIPTION
@xthexder for review
## Problem

Visitors with certain user agents were causing the following undefined method on nil exceptions:
https://exceptions.shopify.com/apps/94348010af650ed81a58f710f5414b9e/errs/51c229aeb74f334708002c48
## Solution

Those regular expressions were only optionally capturing a string, so changing `str.gsub` to `str && str.gsub` will cause `nil` to be returned for that field instead.  For the above mentioned exception, it would just result in the `:os_version` being `nil`.

Added a regression test for that specific browser user-agent.
