### PR TITLE
Add Nexus support (Nexus 5, Nexus 7 & Nexus 10)

### DIFF
--- a/lib/browser_sniffer/patterns.rb
+++ b/lib/browser_sniffer/patterns.rb
@@ -128,7 +128,7 @@ class BrowserSniffer
       ], [:vendor, :model, [:type, :handheld]], [
         /\((bb10);\s(\w+)/i # BlackBerry 10
       ], [[:vendor, 'BlackBerry'], :model, [:type, :handheld]], [
-        /android.+((transfo[prime\s]{4,10}\s\w+|eeepc|slider\s\w+))/i # Asus Tablets
+        /android.+((transfo[prime\s]{4,10}\s\w+|eeepc|slider\s\w+|nexus\s7))/i # Asus Tablets
       ], [[:vendor, 'Asus'], :model, [:type, :tablet]], [
         /(sony)\s(tablet\s[ps])/i # Sony Tablets
       ], [:vendor, :model, [:type, :tablet]], [
@@ -147,7 +147,7 @@ class BrowserSniffer
       ], [[:vendor, 'Motorola'], :model, [:type, :handheld]], [
         /android.+\s((mz60\d|xoom[\s2]{0,2}))\sbuild\//i
       ], [[:vendor, 'Motorola'], :model, [:type, :tablet]], [
-        /android.+((sch-i[89]0\d|shw-m380s|gt-p\d{4}|gt-n8000|sgh-t8[56]9))/i
+        /android.+((sch-i[89]0\d|shw-m380s|gt-p\d{4}|gt-n8000|sgh-t8[56]9|nexus\s10))/i
       ], [[:vendor, 'Samsung'], :model, [:type, :tablet]], [
         # Samsung
         /((s[cgp]h-\w+|gt-\w+|galaxy\snexus))/i,
@@ -163,7 +163,7 @@ class BrowserSniffer
       ], [[:vendor, 'Acer'], :model, [:type, :tablet]], [
         /android\s3\.[-\s\w;]{10}(lg?)-([06cv9]{3,4})/i # LG
       ], [[:vendor, 'LG'], :model, [:type, :tablet]], [
-        /((nexus\s4))/i,
+        /((nexus\s[45]))/i,
         /(lg)[-e;\s\/]+(\w+)*/i
       ], [[:vendor, 'LG'], :model, [:type, :handheld]], [
         /opera\smobi/i,

--- a/test/browser_sniffer_test.rb
+++ b/test/browser_sniffer_test.rb
@@ -464,6 +464,48 @@ class BrowserSnifferTest < MiniTest::Unit::TestCase
       :os_version => "8.1",
       :browser => :ie,
       :major_browser_version => 11
+    },
+    :nexus10 => {
+      :user_agent => "Mozilla/5.0 (Linux; Android 4.2; Nexus 10 Build/JOP19B) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19",
+      :form_factor => :tablet,
+      :ios? => false,
+      :ie11? => false,
+      :android? => true,
+      :desktop? => false,
+      :engine => :webkit,
+      :major_engine_version => 535,
+      :os => :android,
+      :os_version => "4.2",
+      :browser => :chrome,
+      :major_browser_version => 18
+    },
+    :nexus7 => {
+      :user_agent => "Mozilla/5.0 (Linux; Android 4.2; Nexus 7 Build/JOP40C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19",
+      :form_factor => :tablet,
+      :ios? => false,
+      :ie11? => false,
+      :android? => true,
+      :desktop? => false,
+      :engine => :webkit,
+      :major_engine_version => 535,
+      :os => :android,
+      :os_version => "4.2",
+      :browser => :chrome,
+      :major_browser_version => 18
+    },
+    :nexus5 => {
+      :user_agent => "Mozilla/5.0 (Linux; Android 4.4.3; Nexus 5 Build/KTU84M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.141 Mobile Safari/537.36",
+      :form_factor => :handheld,
+      :ios? => false,
+      :ie11? => false,
+      :android? => true,
+      :desktop? => false,
+      :engine => :webkit,
+      :major_engine_version => 537,
+      :os => :android,
+      :os_version => "4.4.3",
+      :browser => :chrome,
+      :major_browser_version => 35
     }
   }
 


### PR DESCRIPTION
Hi !

Nexus 10 and 7 are missing in patterns file so the gem currently recognise them as handheld device.
I also add Nexus 5 in pattern file to add the whole family :)
