### PR TITLE
Adds support for newer iPod Touch devices

### DIFF
--- a/lib/browser_sniffer/patterns.rb
+++ b/lib/browser_sniffer/patterns.rb
@@ -81,7 +81,7 @@ class BrowserSniffer
       ], [[:name, 'Chrome'], :version, :major, [:type, :chrome]], [
         /version\/((\d+)?[\w\.]+).+?mobile\/\w+\s(safari)/i # Mobile Safari
       ], [:version, :major, [:name, 'Mobile Safari'], [:type, :safari]], [
-        /Mozilla\/5.0 \(iPhone;(.*)AppleWebKit\/((\d+)?[\w\.]+).+?(mobile)\/\w?/i # ios webview
+        /Mozilla\/5.0 \((?:iPhone|iPod(?: Touch)?);(.*)AppleWebKit\/((\d+)?[\w\.]+).+?(mobile)\/\w?/i # ios webview
       ], [:version, :major, [:name, 'Mobile Safari'], [:type, :safari]], [
         /version\/((\d+)?[\w\.]+).+?(mobile\s?safari|safari)/i # Safari & Safari Mobile
       ], [:version, :major, :name, [:type, :safari]], [
@@ -119,7 +119,7 @@ class BrowserSniffer
         /\s(nook)[\w\s]+build\/(\w+)/i, # Nook
         /(dell)\s(strea[kpr\s\d]*[\dko])/i # Dell Streak
       ], [:vendor, :model, [:type, :tablet]], [
-        /\((ip[honed]+);.+(apple)/i # iPod/iPhone
+        /\((?:iphone|ipod(?: touch)?);.+(apple)/i # iPod Touch/iPhone
       ], [:model, :vendor, [:name, :iphone], [:type, :handheld]], [
         /(blackberry)[\s-]?(\w+)/i, # BlackBerry
         /(blackberry|benq|palm(?=\-)|sonyericsson|acer|asus|dell|huawei|meizu|motorola)[\s_-]?([\w-]+)*/i, # BenQ/Palm/Sony-Ericsson/Acer/Asus/Dell/Huawei/Meizu/Motorola

--- a/test/browser_sniffer_test.rb
+++ b/test/browser_sniffer_test.rb
@@ -67,6 +67,32 @@ class BrowserSnifferTest < MiniTest::Unit::TestCase
       :browser => :safari,
       :major_browser_version => 3
     },
+    :ipod_touch_ios4 => {
+      :user_agent => "Mozilla/5.0 (iPod; U; CPU iPhone OS 4_3_3 like Mac OS X; ja-jp) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8J2 Safari/6533.18.5",
+      :form_factor => :handheld,
+      :ios? => true,
+      :android? => false,
+      :desktop? => false,
+      :engine => :webkit,
+      :major_engine_version => 533,
+      :os => :ios,
+      :os_version => '4.3.3',
+      :browser => :safari,
+      :major_browser_version => 5
+    },
+    :ipod_touch_ios7 => {
+      :user_agent => "Mozilla/5.0 (iPod touch; CPU iPhone OS 7_0_4 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Version/7.0 Mobile/11B554a Safari/9537.53",
+      :form_factor => :handheld,
+      :ios? => true,
+      :android? => false,
+      :desktop? => false,
+      :engine => :webkit,
+      :major_engine_version => 537,
+      :os => :ios,
+      :os_version => '7.0.4',
+      :browser => :safari,
+      :major_browser_version => 7
+    },
     :nexus_one => {
       :user_agent => "Mozilla/5.0 (Linux; U; Android 2.2; en-us; Nexus One Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1",
       :form_factor => :handheld,
@@ -351,8 +377,8 @@ class BrowserSnifferTest < MiniTest::Unit::TestCase
       :major_engine_version => 533,
       :os => :ios,
       :os_version => '4.3.3',
-      :browser => nil,
-      :browser_name => 'WebKit',
+      :browser => :safari,
+      :browser_name => 'Mobile Safari',
       :major_browser_version => 533
     },
     :ipod_os_4_3_3 => {


### PR DESCRIPTION
These actually declare themselves as "iPod Touch" as opposed to the
old "iPod" way.

Fixes #7 

Ping @ibawt 
