### PR TITLE
Alphabetized browser_sniffer_test.rb for readability

### DIFF
--- a/test/browser_sniffer_test.rb
+++ b/test/browser_sniffer_test.rb
@@ -16,7 +16,7 @@ class BrowserSnifferTest < MiniTest::Unit::TestCase
       :os_version => nil,
       :browser => :opera,
       :major_browser_version => 9
-    }
+    },
     :bb_8830 => {
       :user_agent => "BlackBerry8330/4.3.0 Profile/MIDP-2.0 Configuration/CLDC-1.1 VendorID/105",
       :form_factor => :handheld,
@@ -109,7 +109,7 @@ class BrowserSnifferTest < MiniTest::Unit::TestCase
       :browser => nil,
       :browser_name => 'Excel',
       :major_browser_version => 14
-    
+    },
     :firefox_linux => {
       :user_agent => "Mozilla/5.0 (X11; U; Linux x86_64; de; rv:1.9.2.8) Gecko/20100723 Ubuntu/10.04 (lucid) Firefox/3.6.8",
       :form_factor => :desktop,
@@ -146,19 +146,6 @@ class BrowserSnifferTest < MiniTest::Unit::TestCase
       :major_engine_version => 533,
       :os => :android,
       :os_version => '2.2',
-      :browser => :safari,
-      :major_browser_version => 4
-    },
-    :ipad_old => {
-      :user_agent => "Mozilla/5.0(iPad; U; CPU iPhone OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B314 Safari/531.21.10",
-      :form_factor => :tablet,
-      :ios? => true,
-      :android? => false,
-      :desktop? => false,
-      :engine => :webkit,
-      :major_engine_version => 531,
-      :os => :ios,
-      :os_version => '3.2',
       :browser => :safari,
       :major_browser_version => 4
     },
@@ -200,6 +187,19 @@ class BrowserSnifferTest < MiniTest::Unit::TestCase
       :os_version => 'XP',
       :browser => :ie,
       :major_browser_version => 7
+    },
+    :ipad_old => {
+      :user_agent => "Mozilla/5.0(iPad; U; CPU iPhone OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B314 Safari/531.21.10",
+      :form_factor => :tablet,
+      :ios? => true,
+      :android? => false,
+      :desktop? => false,
+      :engine => :webkit,
+      :major_engine_version => 531,
+      :os => :ios,
+      :os_version => '3.2',
+      :browser => :safari,
+      :major_browser_version => 4
     },
     :ipad_new => {
       :user_agent => "Mozilla/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B334b Safari/531.21.10",
@@ -277,6 +277,19 @@ class BrowserSnifferTest < MiniTest::Unit::TestCase
       :major_engine_version => 534,
       :os => :ios,
       :os_version => '5.0',
+      :browser => :safari,
+      :major_browser_version => 5
+    },
+    :ipod_os_4_3_3 => {
+      :user_agent => "Mozilla/5.0 (iPod; U; CPU iPhone OS 4_3_3 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8J2 Safari/6533.18.5",
+      :form_factor => :handheld,
+      :ios? => true,
+      :android? => false,
+      :desktop? => false,
+      :engine => :webkit,
+      :major_engine_version => 533,
+      :os => :ios,
+      :os_version => '4.3.3',
       :browser => :safari,
       :major_browser_version => 5
     },
@@ -437,19 +450,6 @@ class BrowserSnifferTest < MiniTest::Unit::TestCase
       :os_version => 'Wii',
       :browser => :opera,
       :major_browser_version => 9
-    },
-    :ipod_os_4_3_3 => {
-      :user_agent => "Mozilla/5.0 (iPod; U; CPU iPhone OS 4_3_3 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8J2 Safari/6533.18.5",
-      :form_factor => :handheld,
-      :ios? => true,
-      :android? => false,
-      :desktop? => false,
-      :engine => :webkit,
-      :major_engine_version => 533,
-      :os => :ios,
-      :os_version => '4.3.3',
-      :browser => :safari,
-      :major_browser_version => 5
     },
     :win7_ie11 => {
       :user_agent => "Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:11.0) like Gecko",

--- a/test/browser_sniffer_test.rb
+++ b/test/browser_sniffer_test.rb
@@ -2,6 +2,84 @@ require 'test_helper'
 
 class BrowserSnifferTest < MiniTest::Unit::TestCase
   AGENTS = {
+    :att => {
+      :user_agent => "Opera/9.51 Beta (Microsoft Windows; PPC; Opera Mobi/1718; U; en)",
+      :form_factor => :handheld,
+      :ios? => false,
+      :android? => false,
+      :desktop? => false,
+      :engine => nil,
+      :major_engine_version => nil,
+      :os => :windows,
+      :os_version => nil,
+      :browser => :opera,
+      :major_browser_version => 9
+    }
+    :bb_8830 => {
+      :user_agent => "BlackBerry8330/4.3.0 Profile/MIDP-2.0 Configuration/CLDC-1.1 VendorID/105",
+      :form_factor => :handheld,
+      :ios? => false,
+      :android? => false,
+      :desktop? => false,
+      :engine => nil,
+      :major_engine_version => nil,
+      :os => :blackberry,
+      :os_version => '4.3.0',
+      :browser => nil,
+      :major_browser_version => nil
+    },
+    :bb_torch => {
+      :user_agent => "Mozilla/5.0 (BlackBerry; U; BlackBerry 9800; en) AppleWebKit/534.1+ (KHTML, Like Gecko) Version/6.0.0.141 Mobile Safari/534.1+",
+      :form_factor => :handheld,
+      :ios? => false,
+      :android? => false,
+      :desktop? => false,
+      :engine => :webkit,
+      :major_engine_version => 534,
+      :os => :blackberry,
+      :os_version => nil,
+      :browser => :safari,
+      :major_browser_version => 6
+    },
+    :chrome_mac => {
+      :user_agent => "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_3; en-US) AppleWebKit/534.6 (KHTML, like Gecko) Chrome/6.0.495.0 Safari/534.6",
+      :form_factor => :desktop,
+      :ios? => false,
+      :android? => false,
+      :desktop? => true,
+      :engine => :webkit,
+      :major_engine_version => 534,
+      :os => :mac,
+      :os_version => '10.6.3',
+      :browser => :chrome,
+      :major_browser_version => 6
+    },
+    :chrome_win => {
+      :user_agent => "Mozilla/5.0 (Windows; U; Windows NT 6.0; en-US) AppleWebKit/533.4 (KHTML, like Gecko) Chrome/5.0.375.125 Safari/533.4",
+      :form_factor => :desktop,
+      :ios? => false,
+      :android? => false,
+      :desktop? => true,
+      :engine => :webkit,
+      :major_engine_version => 533,
+      :os => :windows,
+      :os_version => 'Vista',
+      :browser => :chrome,
+      :major_browser_version => 5
+    },
+   :htc_droid => {
+      :user_agent => "Mozilla/5.0 (Linux; U; Android 2.2; nl-nl; Desire_A8181 Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1",
+      :form_factor => :handheld,
+      :ios? => false,
+      :android? => true,
+      :desktop? => false,
+      :engine => :webkit,
+      :major_engine_version => 533,
+      :os => :android,
+      :os_version => '2.2',
+      :browser => :safari,
+      :major_browser_version => 4
+    }
     :ipad_old => {
       :user_agent => "Mozilla/5.0(iPad; U; CPU iPhone OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B314 Safari/531.21.10",
       :form_factor => :tablet,
@@ -106,45 +184,7 @@ class BrowserSnifferTest < MiniTest::Unit::TestCase
       :browser => :safari,
       :major_browser_version => 4
     },
-    :htc_droid => {
-      :user_agent => "Mozilla/5.0 (Linux; U; Android 2.2; nl-nl; Desire_A8181 Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1",
-      :form_factor => :handheld,
-      :ios? => false,
-      :android? => true,
-      :desktop? => false,
-      :engine => :webkit,
-      :major_engine_version => 533,
-      :os => :android,
-      :os_version => '2.2',
-      :browser => :safari,
-      :major_browser_version => 4
-    },
-    :bb_torch => {
-      :user_agent => "Mozilla/5.0 (BlackBerry; U; BlackBerry 9800; en) AppleWebKit/534.1+ (KHTML, Like Gecko) Version/6.0.0.141 Mobile Safari/534.1+",
-      :form_factor => :handheld,
-      :ios? => false,
-      :android? => false,
-      :desktop? => false,
-      :engine => :webkit,
-      :major_engine_version => 534,
-      :os => :blackberry,
-      :os_version => nil,
-      :browser => :safari,
-      :major_browser_version => 6
-    },
-    :bb_8830 => {
-      :user_agent => "BlackBerry8330/4.3.0 Profile/MIDP-2.0 Configuration/CLDC-1.1 VendorID/105",
-      :form_factor => :handheld,
-      :ios? => false,
-      :android? => false,
-      :desktop? => false,
-      :engine => nil,
-      :major_engine_version => nil,
-      :os => :blackberry,
-      :os_version => '4.3.0',
-      :browser => nil,
-      :major_browser_version => nil
-    },
+
     :kindle => {
       :user_agent => "Mozilla/4.0 (compatible; Linux 2.6.22) NetFront/3.4 Kindle/2.0 (screen 600x800)",
       :form_factor => :tablet,
@@ -159,19 +199,6 @@ class BrowserSnifferTest < MiniTest::Unit::TestCase
       :browser_name => 'Kindle',
       :major_browser_version => 2
     },
-    :nokia_classic => {
-      :user_agent => "Nokia3120Classic/2.0 (06.20) Profile/MIDP-2.1 Configuration/CLDC-1.1",
-      :form_factor => :handheld,
-      :ios? => false,
-      :android? => false,
-      :desktop? => false,
-      :engine => nil,
-      :major_engine_version => nil,
-      :os => nil,
-      :os_version => nil,
-      :browser => nil,
-      :major_browser_version => nil
-    },
     :nokia_3200 => {
       :user_agent => "Nokia3200/1.0 (5.29) Profile/MIDP-1.0 Configuration/CLDC-1.0\nUP.Link/6.3.1.13.0",
       :form_factor => :handheld,
@@ -185,19 +212,20 @@ class BrowserSnifferTest < MiniTest::Unit::TestCase
       :browser => nil,
       :major_browser_version => nil
     },
-    :att => {
-      :user_agent => "Opera/9.51 Beta (Microsoft Windows; PPC; Opera Mobi/1718; U; en)",
+    :nokia_classic => {
+      :user_agent => "Nokia3120Classic/2.0 (06.20) Profile/MIDP-2.1 Configuration/CLDC-1.1",
       :form_factor => :handheld,
       :ios? => false,
       :android? => false,
       :desktop? => false,
       :engine => nil,
       :major_engine_version => nil,
-      :os => :windows,
+      :os => nil,
       :os_version => nil,
-      :browser => :opera,
-      :major_browser_version => 9
+      :browser => nil,
+      :major_browser_version => nil
     },
+
     :benq => {
       :user_agent => "BenQ-CF61/1.00/WAP2.0/MIDP2.0/CLDC1.0 UP.Browser/6.3.0.4.c.1.102 (GUI) MMP/2.0",
       :form_factor => :handheld,
@@ -222,6 +250,19 @@ class BrowserSnifferTest < MiniTest::Unit::TestCase
       :os => :android,
       :os_version => '1.6',
       :os => :android,
+      :major_browser_version => 3
+    },
+    :firefox_linux => {
+      :user_agent => "Mozilla/5.0 (X11; U; Linux x86_64; de; rv:1.9.2.8) Gecko/20100723 Ubuntu/10.04 (lucid) Firefox/3.6.8",
+      :form_factor => :desktop,
+      :ios? => false,
+      :android? => false,
+      :desktop? => true,
+      :engine => :gecko,
+      :major_engine_version => 1,
+      :os => :linux,
+      :os_version => '10.04',
+      :browser => :firefox,
       :major_browser_version => 3
     },
     :hp_ipaq => {
@@ -250,19 +291,7 @@ class BrowserSnifferTest < MiniTest::Unit::TestCase
       :browser => :opera,
       :major_browser_version => 8
     },
-    :firefox_linux => {
-      :user_agent => "Mozilla/5.0 (X11; U; Linux x86_64; de; rv:1.9.2.8) Gecko/20100723 Ubuntu/10.04 (lucid) Firefox/3.6.8",
-      :form_factor => :desktop,
-      :ios? => false,
-      :android? => false,
-      :desktop? => true,
-      :engine => :gecko,
-      :major_engine_version => 1,
-      :os => :linux,
-      :os_version => '10.04',
-      :browser => :firefox,
-      :major_browser_version => 3
-    },
+
     :safari_mac => {
       :user_agent => "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_3; en-ca) AppleWebKit/534.6+ (KHTML, like Gecko) Version/5.0 Safari/533.16",
       :form_factor => :desktop,
@@ -276,31 +305,7 @@ class BrowserSnifferTest < MiniTest::Unit::TestCase
       :browser => :safari,
       :major_browser_version => 5
     },
-    :chrome_mac => {
-      :user_agent => "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_3; en-US) AppleWebKit/534.6 (KHTML, like Gecko) Chrome/6.0.495.0 Safari/534.6",
-      :form_factor => :desktop,
-      :ios? => false,
-      :android? => false,
-      :desktop? => true,
-      :engine => :webkit,
-      :major_engine_version => 534,
-      :os => :mac,
-      :os_version => '10.6.3',
-      :browser => :chrome,
-      :major_browser_version => 6
-    },
-    :chrome_win => {
-      :user_agent => "Mozilla/5.0 (Windows; U; Windows NT 6.0; en-US) AppleWebKit/533.4 (KHTML, like Gecko) Chrome/5.0.375.125 Safari/533.4",
-      :form_factor => :desktop,
-      :ios? => false,
-      :android? => false,
-      :desktop? => true,
-      :engine => :webkit,
-      :major_engine_version => 533,
-      :os => :windows,
-      :os_version => 'Vista',
-      :browser => :chrome,
-      :major_browser_version => 5
+
     },
     :ie9 => {
       :user_agent => "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0)",

--- a/test/browser_sniffer_test.rb
+++ b/test/browser_sniffer_test.rb
@@ -42,7 +42,7 @@ class BrowserSnifferTest < MiniTest::Unit::TestCase
       :os_version => nil,
       :browser => :safari,
       :major_browser_version => 6
-   },
+    },
     :benq => {
       :user_agent => "BenQ-CF61/1.00/WAP2.0/MIDP2.0/CLDC1.0 UP.Browser/6.3.0.4.c.1.102 (GUI) MMP/2.0",
       :form_factor => :handheld,
@@ -55,7 +55,7 @@ class BrowserSnifferTest < MiniTest::Unit::TestCase
       :os_version => nil,
       :browser => nil,
       :major_browser_version => nil
-   },
+    },
     :chrome_mac => {
       :user_agent => "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_3; en-US) AppleWebKit/534.6 (KHTML, like Gecko) Chrome/6.0.495.0 Safari/534.6",
       :form_factor => :desktop,
@@ -149,18 +149,18 @@ class BrowserSnifferTest < MiniTest::Unit::TestCase
       :browser => :safari,
       :major_browser_version => 4
     },
-    :ie9 => {
-      :user_agent => "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0)",
+    :ie7 => {
+      :user_agent => "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1; GTB6.4; .NET CLR 1.1.4322; FDM; .NET CLR 2.0.50727; .NET CLR 3.0.04506.30; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729)",
       :form_factor => :desktop,
       :ios? => false,
       :android? => false,
       :desktop? => true,
-      :engine => :trident,
-      :major_engine_version => 5,
+      :engine => nil,
+      :major_engine_version => nil,
       :os => :windows,
-      :os_version => '7',
+      :os_version => 'XP',
       :browser => :ie,
-      :major_browser_version => 9
+      :major_browser_version => 7
     },
     :ie8 => {
       :user_agent => "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; WOW64; Trident/4.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; MDDC)",
@@ -175,31 +175,44 @@ class BrowserSnifferTest < MiniTest::Unit::TestCase
       :browser => :ie,
       :major_browser_version => 8
     },
-    :ie7 => {
-      :user_agent => "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1; GTB6.4; .NET CLR 1.1.4322; FDM; .NET CLR 2.0.50727; .NET CLR 3.0.04506.30; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729)",
+    :ie9 => {
+      :user_agent => "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0)",
       :form_factor => :desktop,
       :ios? => false,
       :android? => false,
       :desktop? => true,
-      :engine => nil,
-      :major_engine_version => nil,
+      :engine => :trident,
+      :major_engine_version => 5,
       :os => :windows,
-      :os_version => 'XP',
+      :os_version => '7',
       :browser => :ie,
-      :major_browser_version => 7
+      :major_browser_version => 9
     },
-    :ipad_old => {
-      :user_agent => "Mozilla/5.0(iPad; U; CPU iPhone OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B314 Safari/531.21.10",
+    :ipad_chrome => {
+      :user_agent => "Mozilla/5.0 (iPad; CPU OS 6_0_1 like Mac OS X; en-us) AppleWebKit/534.46.0 (KHTML, like Gecko) CriOS/21.0.1180.82 Mobile/10A523 Safari/7534.48.3",
       :form_factor => :tablet,
       :ios? => true,
       :android? => false,
       :desktop? => false,
       :engine => :webkit,
-      :major_engine_version => 531,
+      :major_engine_version => 534,
       :os => :ios,
-      :os_version => '3.2',
+      :os_version => '6.0.1',
+      :browser => :chrome,
+      :major_browser_version => 21
+    },
+    :ipad_ios5 => {
+      :user_agent => "Mozilla/5.0 (iPad; CPU OS 5_0 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9A334 Safari/7534.48.3",
+      :form_factor => :tablet,
+      :ios? => true,
+      :android? => false,
+      :desktop? => false,
+      :engine => :webkit,
+      :major_engine_version => 534,
+      :os => :ios,
+      :os_version => '5.0',
       :browser => :safari,
-      :major_browser_version => 4
+      :major_browser_version => 5
     },
     :ipad_new => {
       :user_agent => "Mozilla/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B334b Safari/531.21.10",
@@ -214,18 +227,18 @@ class BrowserSnifferTest < MiniTest::Unit::TestCase
       :browser => :safari,
       :major_browser_version => 4
     },
-    :ipad_chrome => {
-      :user_agent => "Mozilla/5.0 (iPad; CPU OS 6_0_1 like Mac OS X; en-us) AppleWebKit/534.46.0 (KHTML, like Gecko) CriOS/21.0.1180.82 Mobile/10A523 Safari/7534.48.3",
+    :ipad_old => {
+      :user_agent => "Mozilla/5.0(iPad; U; CPU iPhone OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B314 Safari/531.21.10",
       :form_factor => :tablet,
       :ios? => true,
       :android? => false,
       :desktop? => false,
       :engine => :webkit,
-      :major_engine_version => 534,
+      :major_engine_version => 531,
       :os => :ios,
-      :os_version => '6.0.1',
-      :browser => :chrome,
-      :major_browser_version => 21
+      :os_version => '3.2',
+      :browser => :safari,
+      :major_browser_version => 4
     },
     :iphone => {
       :user_agent => "Mozilla/5.0 (iPhone; U; CPU iPhone OS 3_1_2 like Mac OS X; en-us) AppleWebKit/528.18 (KHTML, like Gecko) Version/4.0 Mobile/7D11 Safari/528.16",
@@ -266,19 +279,6 @@ class BrowserSnifferTest < MiniTest::Unit::TestCase
       :browser => :safari,
       :browser_name => 'Mobile Safari',
       :major_browser_version => 537
-    },
-    :ipad_ios5 => {
-      :user_agent => "Mozilla/5.0 (iPad; CPU OS 5_0 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9A334 Safari/7534.48.3",
-      :form_factor => :tablet,
-      :ios? => true,
-      :android? => false,
-      :desktop? => false,
-      :engine => :webkit,
-      :major_engine_version => 534,
-      :os => :ios,
-      :os_version => '5.0',
-      :browser => :safari,
-      :major_browser_version => 5
     },
     :ipod_os_4_3_3 => {
       :user_agent => "Mozilla/5.0 (iPod; U; CPU iPhone OS 4_3_3 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8J2 Safari/6533.18.5",

--- a/test/browser_sniffer_test.rb
+++ b/test/browser_sniffer_test.rb
@@ -1,6 +1,4 @@
-# This list is alphabetized. Strings used are either full or short names of particular devices (e.g. bb_8830 for
-# BlackBerry 8830) or they are "browser_os" (e.g. "firefox_linux", "safari_mac"). Please keep to that format when adding new
-# user-agent strings to test for.
+# This list is alphabetized.
 
 require 'test_helper'
 
@@ -44,7 +42,20 @@ class BrowserSnifferTest < MiniTest::Unit::TestCase
       :os_version => nil,
       :browser => :safari,
       :major_browser_version => 6
-    },
+   },
+    :benq => {
+      :user_agent => "BenQ-CF61/1.00/WAP2.0/MIDP2.0/CLDC1.0 UP.Browser/6.3.0.4.c.1.102 (GUI) MMP/2.0",
+      :form_factor => :handheld,
+      :ios? => false,
+      :android? => false,
+      :desktop? => false,
+      :engine => nil,
+      :major_engine_version => nil,
+      :os => nil,
+      :os_version => nil,
+      :browser => nil,
+      :major_browser_version => nil
+   },
     :chrome_mac => {
       :user_agent => "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_3; en-US) AppleWebKit/534.6 (KHTML, like Gecko) Chrome/6.0.495.0 Safari/534.6",
       :form_factor => :desktop,
@@ -71,178 +82,6 @@ class BrowserSnifferTest < MiniTest::Unit::TestCase
       :browser => :chrome,
       :major_browser_version => 5
     },
-   :htc_droid => {
-      :user_agent => "Mozilla/5.0 (Linux; U; Android 2.2; nl-nl; Desire_A8181 Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1",
-      :form_factor => :handheld,
-      :ios? => false,
-      :android? => true,
-      :desktop? => false,
-      :engine => :webkit,
-      :major_engine_version => 533,
-      :os => :android,
-      :os_version => '2.2',
-      :browser => :safari,
-      :major_browser_version => 4
-    }
-    :ipad_old => {
-      :user_agent => "Mozilla/5.0(iPad; U; CPU iPhone OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B314 Safari/531.21.10",
-      :form_factor => :tablet,
-      :ios? => true,
-      :android? => false,
-      :desktop? => false,
-      :engine => :webkit,
-      :major_engine_version => 531,
-      :os => :ios,
-      :os_version => '3.2',
-      :browser => :safari,
-      :major_browser_version => 4
-    },
-    :ipad_new => {
-      :user_agent => "Mozilla/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B334b Safari/531.21.10",
-      :form_factor => :tablet,
-      :ios? => true,
-      :android? => false,
-      :desktop? => false,
-      :engine => :webkit,
-      :major_engine_version => 531,
-      :os => :ios,
-      :os_version => '3.2',
-      :browser => :safari,
-      :major_browser_version => 4
-    },
-    :ipad_chrome => {
-      :user_agent => "Mozilla/5.0 (iPad; CPU OS 6_0_1 like Mac OS X; en-us) AppleWebKit/534.46.0 (KHTML, like Gecko) CriOS/21.0.1180.82 Mobile/10A523 Safari/7534.48.3",
-      :form_factor => :tablet,
-      :ios? => true,
-      :android? => false,
-      :desktop? => false,
-      :engine => :webkit,
-      :major_engine_version => 534,
-      :os => :ios,
-      :os_version => '6.0.1',
-      :browser => :chrome,
-      :major_browser_version => 21
-    },
-    :iphone => {
-      :user_agent => "Mozilla/5.0 (iPhone; U; CPU iPhone OS 3_1_2 like Mac OS X; en-us) AppleWebKit/528.18 (KHTML, like Gecko) Version/4.0 Mobile/7D11 Safari/528.16",
-      :form_factor => :handheld,
-      :ios? => true,
-      :android? => false,
-      :desktop? => false,
-      :engine => :webkit,
-      :major_engine_version => 528,
-      :os => :ios,
-      :os_version => '3.1.2',
-      :browser => :safari,
-      :major_browser_version => 4
-    },
-    :ipod_touch => {
-      :user_agent => "Mozilla/5.0 (iPod; U; CPU iPhone OS 2_2_1 like Mac OS X; en-us) AppleWebKit/525.18.1 (KHTML, like Gecko) Version/3.1.1 Mobile/5H11a Safari/525.20",
-      :form_factor => :handheld,
-      :ios? => true,
-      :android? => false,
-      :desktop? => false,
-      :engine => :webkit,
-      :major_engine_version => 525,
-      :os => :ios,
-      :os_version => '2.2.1',
-      :browser => :safari,
-      :major_browser_version => 3
-    },
-    :ipod_touch_ios4 => {
-      :user_agent => "Mozilla/5.0 (iPod; U; CPU iPhone OS 4_3_3 like Mac OS X; ja-jp) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8J2 Safari/6533.18.5",
-      :form_factor => :handheld,
-      :ios? => true,
-      :android? => false,
-      :desktop? => false,
-      :engine => :webkit,
-      :major_engine_version => 533,
-      :os => :ios,
-      :os_version => '4.3.3',
-      :browser => :safari,
-      :major_browser_version => 5
-    },
-    :ipod_touch_ios7 => {
-      :user_agent => "Mozilla/5.0 (iPod touch; CPU iPhone OS 7_0_4 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Version/7.0 Mobile/11B554a Safari/9537.53",
-      :form_factor => :handheld,
-      :ios? => true,
-      :android? => false,
-      :desktop? => false,
-      :engine => :webkit,
-      :major_engine_version => 537,
-      :os => :ios,
-      :os_version => '7.0.4',
-      :browser => :safari,
-      :major_browser_version => 7
-    },
-    :nexus_one => {
-      :user_agent => "Mozilla/5.0 (Linux; U; Android 2.2; en-us; Nexus One Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1",
-      :form_factor => :handheld,
-      :ios? => false,
-      :android? => true,
-      :desktop? => false,
-      :engine => :webkit,
-      :major_engine_version => 533,
-      :os => :android,
-      :os_version => '2.2',
-      :browser => :safari,
-      :major_browser_version => 4
-    },
-
-    :kindle => {
-      :user_agent => "Mozilla/4.0 (compatible; Linux 2.6.22) NetFront/3.4 Kindle/2.0 (screen 600x800)",
-      :form_factor => :tablet,
-      :ios? => false,
-      :android? => false,
-      :desktop? => false,
-      :engine => nil,
-      :major_engine_version => 3,
-      :os => :linux,
-      :os_version => '2.6.22',
-      :browser => nil,
-      :browser_name => 'Kindle',
-      :major_browser_version => 2
-    },
-    :nokia_3200 => {
-      :user_agent => "Nokia3200/1.0 (5.29) Profile/MIDP-1.0 Configuration/CLDC-1.0\nUP.Link/6.3.1.13.0",
-      :form_factor => :handheld,
-      :ios? => false,
-      :android? => false,
-      :desktop? => false,
-      :engine => nil,
-      :major_engine_version => nil,
-      :os => nil,
-      :os_version => nil,
-      :browser => nil,
-      :major_browser_version => nil
-    },
-    :nokia_classic => {
-      :user_agent => "Nokia3120Classic/2.0 (06.20) Profile/MIDP-2.1 Configuration/CLDC-1.1",
-      :form_factor => :handheld,
-      :ios? => false,
-      :android? => false,
-      :desktop? => false,
-      :engine => nil,
-      :major_engine_version => nil,
-      :os => nil,
-      :os_version => nil,
-      :browser => nil,
-      :major_browser_version => nil
-    },
-
-    :benq => {
-      :user_agent => "BenQ-CF61/1.00/WAP2.0/MIDP2.0/CLDC1.0 UP.Browser/6.3.0.4.c.1.102 (GUI) MMP/2.0",
-      :form_factor => :handheld,
-      :ios? => false,
-      :android? => false,
-      :desktop? => false,
-      :engine => nil,
-      :major_engine_version => nil,
-      :os => nil,
-      :os_version => nil,
-      :browser => nil,
-      :major_browser_version => nil
-    },
     :dell_streak => {
       :user_agent => "Mozilla/5.0 (Linux; U; Android 1.6; en-gb; Dell Streak Build/Donut AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/ 525.20.1",
       :form_factor => :tablet,
@@ -256,6 +95,21 @@ class BrowserSnifferTest < MiniTest::Unit::TestCase
       :os => :android,
       :major_browser_version => 3
     },
+    :excel_mac => {
+      :user_agent => "Mozilla/5.0 (Macintosh; Intel Mac OS X) Excel/14.34.0",
+      :form_factor => :desktop,
+      :ios? => false,
+      :android? => false,
+      :desktop? => true,
+      :ie11? => false,
+      :engine => nil,
+      :major_engine_version => nil,
+      :os => :mac,
+      :os_version => nil,
+      :browser => nil,
+      :browser_name => 'Excel',
+      :major_browser_version => 14
+    
     :firefox_linux => {
       :user_agent => "Mozilla/5.0 (X11; U; Linux x86_64; de; rv:1.9.2.8) Gecko/20100723 Ubuntu/10.04 (lucid) Firefox/3.6.8",
       :form_factor => :desktop,
@@ -282,34 +136,31 @@ class BrowserSnifferTest < MiniTest::Unit::TestCase
       :browser => :ie,
       :major_browser_version => 4
     },
-    :nintendo_ds => {
-      :user_agent => "Mozilla/4.0 (compatible; MSIE 6.0; Nitro) Opera 8.50 [en Mozilla/4.0 (compatible; MSIE 6.0; Nitro) Opera 8.50 [ja]",
-      :form_factor => :console,
+    :htc_droid => {
+      :user_agent => "Mozilla/5.0 (Linux; U; Android 2.2; nl-nl; Desire_A8181 Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1",
+      :form_factor => :handheld,
       :ios? => false,
+      :android? => true,
+      :desktop? => false,
+      :engine => :webkit,
+      :major_engine_version => 533,
+      :os => :android,
+      :os_version => '2.2',
+      :browser => :safari,
+      :major_browser_version => 4
+    },
+    :ipad_old => {
+      :user_agent => "Mozilla/5.0(iPad; U; CPU iPhone OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B314 Safari/531.21.10",
+      :form_factor => :tablet,
+      :ios? => true,
       :android? => false,
       :desktop? => false,
-      :engine => nil,
-      :major_engine_version => nil,
-      :os => nil,
-      :os_version => nil,
-      :browser => :opera,
-      :major_browser_version => 8
-    },
-
-    :safari_mac => {
-      :user_agent => "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_3; en-ca) AppleWebKit/534.6+ (KHTML, like Gecko) Version/5.0 Safari/533.16",
-      :form_factor => :desktop,
-      :ios? => false,
-      :android? => false,
-      :desktop? => true,
       :engine => :webkit,
-      :major_engine_version => 534,
-      :os => :mac,
-      :os_version => '10.6.3',
+      :major_engine_version => 531,
+      :os => :ios,
+      :os_version => '3.2',
       :browser => :safari,
-      :major_browser_version => 5
-    },
-
+      :major_browser_version => 4
     },
     :ie9 => {
       :user_agent => "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0)",
@@ -350,58 +201,44 @@ class BrowserSnifferTest < MiniTest::Unit::TestCase
       :browser => :ie,
       :major_browser_version => 7
     },
-    :opera_win => {
-      :user_agent => "Opera/9.80 (Windows NT 6.1; U; en) Presto/2.5.24 Version/10.54",
-      :form_factor => :desktop,
-      :ios? => false,
-      :android? => false,
-      :desktop? => true,
-      :engine => :presto,
-      :major_engine_version => 2,
-      :os => :windows,
-      :os_version => '7',
-      :browser => :opera,
-      :major_browser_version => 9
-    },
-    :wii => {
-      :user_agent => "Opera/9.00 (Nintendo Wii; U; ; 1038-58; Wii Shop Channel/1.0; en)",
-      :form_factor => :console,
-      :ios? => false,
+    :ipad_new => {
+      :user_agent => "Mozilla/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B334b Safari/531.21.10",
+      :form_factor => :tablet,
+      :ios? => true,
       :android? => false,
       :desktop? => false,
-      :engine => nil,
-      :major_engine_version => nil,
-      :os => nil,
-      :os_version => 'Wii',
-      :browser => :opera,
-      :major_browser_version => 9
+      :engine => :webkit,
+      :major_engine_version => 531,
+      :os => :ios,
+      :os_version => '3.2',
+      :browser => :safari,
+      :major_browser_version => 4
     },
-    :springboard_launched_ipod_browser => {
-      :user_agent => "Mozilla/5.0 (iPod; U; CPU iPhone OS 4_3_3 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Mobile/8J2",
+    :ipad_chrome => {
+      :user_agent => "Mozilla/5.0 (iPad; CPU OS 6_0_1 like Mac OS X; en-us) AppleWebKit/534.46.0 (KHTML, like Gecko) CriOS/21.0.1180.82 Mobile/10A523 Safari/7534.48.3",
+      :form_factor => :tablet,
+      :ios? => true,
+      :android? => false,
+      :desktop? => false,
+      :engine => :webkit,
+      :major_engine_version => 534,
+      :os => :ios,
+      :os_version => '6.0.1',
+      :browser => :chrome,
+      :major_browser_version => 21
+    },
+    :iphone => {
+      :user_agent => "Mozilla/5.0 (iPhone; U; CPU iPhone OS 3_1_2 like Mac OS X; en-us) AppleWebKit/528.18 (KHTML, like Gecko) Version/4.0 Mobile/7D11 Safari/528.16",
       :form_factor => :handheld,
       :ios? => true,
       :android? => false,
       :desktop? => false,
       :engine => :webkit,
-      :major_engine_version => 533,
+      :major_engine_version => 528,
       :os => :ios,
-      :os_version => '4.3.3',
+      :os_version => '3.1.2',
       :browser => :safari,
-      :browser_name => 'Mobile Safari',
-      :major_browser_version => 533
-    },
-    :ipod_os_4_3_3 => {
-      :user_agent => "Mozilla/5.0 (iPod; U; CPU iPhone OS 4_3_3 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8J2 Safari/6533.18.5",
-      :form_factor => :handheld,
-      :ios? => true,
-      :android? => false,
-      :desktop? => false,
-      :engine => :webkit,
-      :major_engine_version => 533,
-      :os => :ios,
-      :os_version => '4.3.3',
-      :browser => :safari,
-      :major_browser_version => 5
+      :major_browser_version => 4
     },
     :iphone_4S => {
       :user_agent => "Mozilla/5.0 (iPhone; CPU iPhone OS 5_0 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9A334 Safari/7534.48.3",
@@ -443,20 +280,176 @@ class BrowserSnifferTest < MiniTest::Unit::TestCase
       :browser => :safari,
       :major_browser_version => 5
     },
-    :excel_mac => {
-      :user_agent => "Mozilla/5.0 (Macintosh; Intel Mac OS X) Excel/14.34.0",
+    :ipod_touch => {
+      :user_agent => "Mozilla/5.0 (iPod; U; CPU iPhone OS 2_2_1 like Mac OS X; en-us) AppleWebKit/525.18.1 (KHTML, like Gecko) Version/3.1.1 Mobile/5H11a Safari/525.20",
+      :form_factor => :handheld,
+      :ios? => true,
+      :android? => false,
+      :desktop? => false,
+      :engine => :webkit,
+      :major_engine_version => 525,
+      :os => :ios,
+      :os_version => '2.2.1',
+      :browser => :safari,
+      :major_browser_version => 3
+    },
+    :ipod_touch_ios4 => {
+      :user_agent => "Mozilla/5.0 (iPod; U; CPU iPhone OS 4_3_3 like Mac OS X; ja-jp) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8J2 Safari/6533.18.5",
+      :form_factor => :handheld,
+      :ios? => true,
+      :android? => false,
+      :desktop? => false,
+      :engine => :webkit,
+      :major_engine_version => 533,
+      :os => :ios,
+      :os_version => '4.3.3',
+      :browser => :safari,
+      :major_browser_version => 5
+    },
+    :ipod_touch_ios7 => {
+      :user_agent => "Mozilla/5.0 (iPod touch; CPU iPhone OS 7_0_4 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Version/7.0 Mobile/11B554a Safari/9537.53",
+      :form_factor => :handheld,
+      :ios? => true,
+      :android? => false,
+      :desktop? => false,
+      :engine => :webkit,
+      :major_engine_version => 537,
+      :os => :ios,
+      :os_version => '7.0.4',
+      :browser => :safari,
+      :major_browser_version => 7
+    },
+    :kindle => {
+      :user_agent => "Mozilla/4.0 (compatible; Linux 2.6.22) NetFront/3.4 Kindle/2.0 (screen 600x800)",
+      :form_factor => :tablet,
+      :ios? => false,
+      :android? => false,
+      :desktop? => false,
+      :engine => nil,
+      :major_engine_version => 3,
+      :os => :linux,
+      :os_version => '2.6.22',
+      :browser => nil,
+      :browser_name => 'Kindle',
+      :major_browser_version => 2
+    },
+    :nexus_one => {
+      :user_agent => "Mozilla/5.0 (Linux; U; Android 2.2; en-us; Nexus One Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1",
+      :form_factor => :handheld,
+      :ios? => false,
+      :android? => true,
+      :desktop? => false,
+      :engine => :webkit,
+      :major_engine_version => 533,
+      :os => :android,
+      :os_version => '2.2',
+      :browser => :safari,
+      :major_browser_version => 4
+    },
+    :nintendo_ds => {
+      :user_agent => "Mozilla/4.0 (compatible; MSIE 6.0; Nitro) Opera 8.50 [en Mozilla/4.0 (compatible; MSIE 6.0; Nitro) Opera 8.50 [ja]",
+      :form_factor => :console,
+      :ios? => false,
+      :android? => false,
+      :desktop? => false,
+      :engine => nil,
+      :major_engine_version => nil,
+      :os => nil,
+      :os_version => nil,
+      :browser => :opera,
+      :major_browser_version => 8
+    },
+    :nokia_3200 => {
+      :user_agent => "Nokia3200/1.0 (5.29) Profile/MIDP-1.0 Configuration/CLDC-1.0\nUP.Link/6.3.1.13.0",
+      :form_factor => :handheld,
+      :ios? => false,
+      :android? => false,
+      :desktop? => false,
+      :engine => nil,
+      :major_engine_version => nil,
+      :os => nil,
+      :os_version => nil,
+      :browser => nil,
+      :major_browser_version => nil
+    },
+    :nokia_classic => {
+      :user_agent => "Nokia3120Classic/2.0 (06.20) Profile/MIDP-2.1 Configuration/CLDC-1.1",
+      :form_factor => :handheld,
+      :ios? => false,
+      :android? => false,
+      :desktop? => false,
+      :engine => nil,
+      :major_engine_version => nil,
+      :os => nil,
+      :os_version => nil,
+      :browser => nil,
+      :major_browser_version => nil
+    },
+    :opera_win => {
+      :user_agent => "Opera/9.80 (Windows NT 6.1; U; en) Presto/2.5.24 Version/10.54",
       :form_factor => :desktop,
       :ios? => false,
       :android? => false,
       :desktop? => true,
-      :ie11? => false,
+      :engine => :presto,
+      :major_engine_version => 2,
+      :os => :windows,
+      :os_version => '7',
+      :browser => :opera,
+      :major_browser_version => 9
+    },
+    :safari_mac => {
+      :user_agent => "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_3; en-ca) AppleWebKit/534.6+ (KHTML, like Gecko) Version/5.0 Safari/533.16",
+      :form_factor => :desktop,
+      :ios? => false,
+      :android? => false,
+      :desktop? => true,
+      :engine => :webkit,
+      :major_engine_version => 534,
+      :os => :mac,
+      :os_version => '10.6.3',
+      :browser => :safari,
+      :major_browser_version => 5
+    },
+    :springboard_launched_ipod_browser => {
+      :user_agent => "Mozilla/5.0 (iPod; U; CPU iPhone OS 4_3_3 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Mobile/8J2",
+      :form_factor => :handheld,
+      :ios? => true,
+      :android? => false,
+      :desktop? => false,
+      :engine => :webkit,
+      :major_engine_version => 533,
+      :os => :ios,
+      :os_version => '4.3.3',
+      :browser => :safari,
+      :browser_name => 'Mobile Safari',
+      :major_browser_version => 533
+    },
+    :wii => {
+      :user_agent => "Opera/9.00 (Nintendo Wii; U; ; 1038-58; Wii Shop Channel/1.0; en)",
+      :form_factor => :console,
+      :ios? => false,
+      :android? => false,
+      :desktop? => false,
       :engine => nil,
       :major_engine_version => nil,
-      :os => :mac,
-      :os_version => nil,
-      :browser => nil,
-      :browser_name => 'Excel',
-      :major_browser_version => 14
+      :os => nil,
+      :os_version => 'Wii',
+      :browser => :opera,
+      :major_browser_version => 9
+    },
+    :ipod_os_4_3_3 => {
+      :user_agent => "Mozilla/5.0 (iPod; U; CPU iPhone OS 4_3_3 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8J2 Safari/6533.18.5",
+      :form_factor => :handheld,
+      :ios? => true,
+      :android? => false,
+      :desktop? => false,
+      :engine => :webkit,
+      :major_engine_version => 533,
+      :os => :ios,
+      :os_version => '4.3.3',
+      :browser => :safari,
+      :major_browser_version => 5
     },
     :win7_ie11 => {
       :user_agent => "Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:11.0) like Gecko",

--- a/test/browser_sniffer_test.rb
+++ b/test/browser_sniffer_test.rb
@@ -1,3 +1,7 @@
+# This list is alphabetized. Strings used are either full or short names of particular devices (e.g. bb_8830 for
+# BlackBerry 8830) or they are "browser_os" (e.g. "firefox_linux", "safari_mac"). Please keep to that format when adding new
+# user-agent strings to test for.
+
 require 'test_helper'
 
 class BrowserSnifferTest < MiniTest::Unit::TestCase


### PR DESCRIPTION
I alphabetized the different form factors listed in this .rb file by the string used for them. This may make it easier for others to read through the code, and for others to know where to add new form factors in the future. I hope you find it useful!

Thanks,
Adam Saunders
