### PR TITLE
Adding IE11 on Win10 pattern

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,5 @@ rvm:
   - 2.1
   - jruby
 
+before_install: gem update bundler
 script: bundle exec rake test

--- a/lib/browser_sniffer/patterns.rb
+++ b/lib/browser_sniffer/patterns.rb
@@ -35,6 +35,7 @@ class BrowserSniffer
           'NT 6.1' => '7',
           'NT 6.2' => '8',
           'NT 6.3' => '8.1',
+          'NT 10.0' => '10',
           'ARM' => 'RT'
         }
       }
@@ -62,6 +63,8 @@ class BrowserSniffer
       ], [:name, :version, :major, [:type, :ie]], [
         /Mozilla\/5.0.*Windows NT 6\.\d.*Trident\/7\.\d.*rv:(\d+)\.\d*/i #IE11 on Win7
       ], [:major, [:version, 7], [:name, 'Internet Explorer'], [:type, :ie]], [
+        /Mozilla\/5.0.*Windows NT 10\.\d.*Trident\/7\.\d.*rv:(\d+)\.\d*.*like\sGecko/i #IE11 on Win10
+      ], [:major, [:version, 10], [:name, 'Internet Explorer'], [:type, :ie]], [
         # Webkit/KHTML based
         /(rekonq)\/?((\d+)[\w\.]+)*/i, # Rekonq
         /(flock|rockmelt|midori|epiphany|silk|skyfire|ovibrowser|bolt)\/((\d+)?[\w\.-]+)/i # Chromium/Flock/RockMelt/Midori/Epiphany/Silk/Skyfire/Bolt

--- a/lib/browser_sniffer/version.rb
+++ b/lib/browser_sniffer/version.rb
@@ -1,3 +1,3 @@
 class BrowserSniffer
-  VERSION = "1.0.7"
+  VERSION = "1.0.8"
 end

--- a/test/browser_sniffer_test.rb
+++ b/test/browser_sniffer_test.rb
@@ -490,6 +490,20 @@ class BrowserSnifferTest < MiniTest::Unit::TestCase
       :os_version => "8.1",
       :browser => :ie,
       :major_browser_version => 11
+    },
+    :win10_ie11 => {
+      :user_agent => "Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; .NET4.0C; .NET4.0E; .NET CLR 2.0.50727; .NET CLR 3.0.30729; .NET CLR 3.5.30729; rv:11.0) like Gecko",
+      :form_factor => :desktop,
+      :ios? => false,
+      :ie11? => true,
+      :android? => false,
+      :desktop? => true,
+      :engine => :trident,
+      :major_engine_version => 7,
+      :os => :windows,
+      :os_version => "10",
+      :browser => :ie,
+      :major_browser_version => 11
     }
   }
 


### PR DESCRIPTION
Microsoft [changed the user agent string for IE11 on Windows 10](https://msdn.microsoft.com/en-us/library/hh869301(v=vs.85).aspx), particularly the part that reports the OS from `NT 6` to `NT 10.0`.

The inability to detect IE11 on Win10 caused the following issue: https://github.com/Shopify/shopify/issues/65214

Wasn't sure if this change constituted more than a minor version bump.

Once this ships, I'll bump the `browser_sniffer` version in Shopify.

Ping @xthexder @christianblais for review, please.
cc: @vernalkick 