### PR TITLE
Ipad firefox

### DIFF
--- a/lib/browser_sniffer/patterns.rb
+++ b/lib/browser_sniffer/patterns.rb
@@ -86,7 +86,7 @@ class BrowserSniffer
       ], [[:name, 'Chrome'], :version, :major, [:type, :chrome]], [
         /version\/((\d+)?[\w\.]+).+?mobile\/\w+\s(safari)/i # Mobile Safari
       ], [:version, :major, [:name, 'Mobile Safari'], [:type, :safari]], [
-        /Mozilla\/5.0 \((?:iPhone|iPod(?: Touch)?);(.*)AppleWebKit\/((\d+)?[\w\.]+).+?(mobile)\/\w?/i # ios webview
+        /Mozilla\/5.0 \((?:iPhone|iPad|iPod(?: Touch)?);(.*)AppleWebKit\/((\d+)?[\w\.]+).+?(mobile)\/\w?/i # ios webview
       ], [:version, :major, [:name, 'Mobile Safari'], [:type, :safari]], [
         /version\/((\d+)?[\w\.]+).+?(mobile\s?safari|safari)/i # Safari & Safari Mobile
       ], [:version, :major, :name, [:type, :safari]], [

--- a/lib/browser_sniffer/version.rb
+++ b/lib/browser_sniffer/version.rb
@@ -1,3 +1,3 @@
 class BrowserSniffer
-  VERSION = "1.0.9"
+  VERSION = "1.0.10"
 end

--- a/test/browser_sniffer_test.rb
+++ b/test/browser_sniffer_test.rb
@@ -423,7 +423,7 @@ class BrowserSnifferTest < MiniTest::Unit::TestCase
     },
     :ipad_ios10_webview => {
       :user_agent => "Mozilla/5.0 (iPad; CPU OS 10_2_1 like Mac OS X) AppleWebKit/602.4.6 (KHTML, like Gecko) FxiOS/6.1 Mobile/14D27 Safari/602.4.6",
-      :form_factor => :handheld,
+      :form_factor => :tablet,
       :ios? => true,
       :android? => false,
       :desktop? => false,

--- a/test/browser_sniffer_test.rb
+++ b/test/browser_sniffer_test.rb
@@ -421,6 +421,20 @@ class BrowserSnifferTest < MiniTest::Unit::TestCase
       :browser_name => 'Mobile Safari',
       :major_browser_version => 537
     },
+    :ipad_ios10_webview => {
+      :user_agent => "Mozilla/5.0 (iPad; CPU OS 10_2_1 like Mac OS X) AppleWebKit/602.4.6 (KHTML, like Gecko) FxiOS/6.1 Mobile/14D27 Safari/602.4.6",
+      :form_factor => :handheld,
+      :ios? => true,
+      :android? => false,
+      :desktop? => false,
+      :engine => :webkit,
+      :major_engine_version => 602,
+      :os => :ios,
+      :os_version => '10.2.1',
+      :browser => :safari,
+      :browser_name => 'Mobile Safari',
+      :major_browser_version => 602
+    },
     :ipad_ios5 => {
       :user_agent => "Mozilla/5.0 (iPad; CPU OS 5_0 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9A334 Safari/7534.48.3",
       :form_factor => :tablet,


### PR DESCRIPTION
When installing firefox on iPad, the browser sniffer is not detecting the version properly. This commit updates the regex to match firefox on iPad

![img_0084](https://cloud.githubusercontent.com/assets/739905/23916874/f519bd6a-08c3-11e7-8b15-ba115c79dbf6.PNG)