### PR TITLE
Add Firefox on iOS

### DIFF
--- a/lib/browser_sniffer/patterns.rb
+++ b/lib/browser_sniffer/patterns.rb
@@ -84,6 +84,8 @@ class BrowserSniffer
       ], [[:name, 'Dolphin'], :version, :major], [
         /((?:android.+)crmo|crios)\/((\d+)?[\w\.]+)/i # Chrome for Android/iOS
       ], [[:name, 'Chrome'], :version, :major, [:type, :chrome]], [
+        /(FxiOS)\/((\d+)?[\w\.]+)/i # Firefox for iOS
+      ], [[:name, 'Mobile Firefox'], :version, :major, [:type, :firefox]], [
         /version\/((\d+)?[\w\.]+).+?mobile\/\w+\s(safari)/i # Mobile Safari
       ], [:version, :major, [:name, 'Mobile Safari'], [:type, :safari]], [
         /Mozilla\/5.0 \((?:iPhone|iPad|iPod(?: Touch)?);(.*)AppleWebKit\/((\d+)?[\w\.]+).+?(mobile)\/\w?/i # ios webview

--- a/lib/browser_sniffer/version.rb
+++ b/lib/browser_sniffer/version.rb
@@ -1,3 +1,3 @@
 class BrowserSniffer
-  VERSION = "1.0.10"
+  VERSION = "1.0.11"
 end

--- a/test/browser_sniffer_test.rb
+++ b/test/browser_sniffer_test.rb
@@ -431,9 +431,9 @@ class BrowserSnifferTest < MiniTest::Unit::TestCase
       :major_engine_version => 602,
       :os => :ios,
       :os_version => '10.2.1',
-      :browser => :safari,
-      :browser_name => 'Mobile Safari',
-      :major_browser_version => 602
+      :browser => :firefox,
+      :browser_name => 'Mobile Firefox',
+      :major_browser_version => 6
     },
     :ipad_ios5 => {
       :user_agent => "Mozilla/5.0 (iPad; CPU OS 5_0 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9A334 Safari/7534.48.3",


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Firefox on iOS is using webviews and its userAgent is different.

Related to [106936](https://github.com/Shopify/shopify/issues/106936)
