### PR TITLE
Change browser :type for Firefox on iOS

### DIFF
--- a/lib/browser_sniffer/patterns.rb
+++ b/lib/browser_sniffer/patterns.rb
@@ -85,7 +85,7 @@ class BrowserSniffer
         /((?:android.+)crmo|crios)\/((\d+)?[\w\.]+)/i # Chrome for Android/iOS
       ], [[:name, 'Chrome'], :version, :major, [:type, :chrome]], [
         /(FxiOS)\/((\d+)?[\w\.]+)/i # Firefox for iOS
-      ], [[:name, 'Mobile Firefox'], :version, :major, [:type, :firefox]], [
+      ], [[:name, 'Mobile Firefox'], :version, :major, [:type, :firefoxios]], [
         /version\/((\d+)?[\w\.]+).+?mobile\/\w+\s(safari)/i # Mobile Safari
       ], [:version, :major, [:name, 'Mobile Safari'], [:type, :safari]], [
         /Mozilla\/5.0 \((?:iPhone|iPad|iPod(?: Touch)?);(.*)AppleWebKit\/((\d+)?[\w\.]+).+?(mobile)\/\w?/i # ios webview

--- a/lib/browser_sniffer/version.rb
+++ b/lib/browser_sniffer/version.rb
@@ -1,3 +1,3 @@
 class BrowserSniffer
-  VERSION = "1.0.11"
+  VERSION = "1.0.12"
 end

--- a/test/browser_sniffer_test.rb
+++ b/test/browser_sniffer_test.rb
@@ -431,7 +431,7 @@ class BrowserSnifferTest < MiniTest::Unit::TestCase
       :major_engine_version => 602,
       :os => :ios,
       :os_version => '10.2.1',
-      :browser => :firefox,
+      :browser => :firefoxios,
       :browser_name => 'Mobile Firefox',
       :major_browser_version => 6
     },


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Firefox on iOS does not match its version number with its desktop counterpart. It's understandable as its not the same engine (one is wekbit and the other gecko) but that makes it harder to consume in apps. Most of our browser checks only check the browser name and version, not the OS it's on. 

**How is this accomplished?**
Rename the type to `firefoxios`