### PR TITLE
fixed ie regex when IE version < 11

### DIFF
--- a/lib/browser_sniffer/patterns.rb
+++ b/lib/browser_sniffer/patterns.rb
@@ -59,7 +59,7 @@ class BrowserSniffer
         # Trident based
         /(avant\s|iemobile|slim|baidu)(?:browser)?[\/\s]?((\d+)?[\w\.]*)/i # Avant/IEMobile/SlimBrowser/Baidu
       ], [:name, :version, :major], [
-        /(?:ms|\()(ie)\s((\d+)?[\w\.]+)/i # Internet Explorer
+        /(?:ms|\()(ie)\s((\d+)[\w\.]+)/i # Internet Explorer
       ], [:name, :version, :major, [:type, :ie]], [
         /Edge\/(\d+).\d+/i #Edge
       ], [:major, [:version, 10], [:name, 'Edge'], [:type, :edge]], [

--- a/lib/browser_sniffer/version.rb
+++ b/lib/browser_sniffer/version.rb
@@ -1,3 +1,3 @@
 class BrowserSniffer
-  VERSION = "1.0.12"
+  VERSION = "1.0.13"
 end

--- a/test/browser_sniffer_test.rb
+++ b/test/browser_sniffer_test.rb
@@ -532,6 +532,19 @@ class BrowserSnifferTest < MiniTest::Unit::TestCase
       :os_version => "10",
       :browser => :edge,
       :major_browser_version => 12
+    },
+    :daum => {
+      :user_agent => "Mozilla/5.0 (compatible; MSIE or Firefox mutant;) Daum 4.1",
+      :form_factor => :desktop,
+      :ios? => false,
+      :android? => false,
+      :desktop? => true,
+      :engine => nil,
+      :major_engine_version => nil,
+      :os => nil,
+      :os_version => nil,
+      :browser => nil,
+      :major_browser_version => nil
     }
   }
 


### PR DESCRIPTION
This PR is changing the IE regex so that it looks for a version number when MSIE is present in the user agent string. Normally, there is a version following MSIE. [MSIE is only used in IE version below 11](https://msdn.microsoft.com/en-us/library/ms537503(v=vs.85).aspx).

This was problematic because a user agent like this: `Mozilla/5.0 (compatible; MSIE or Firefox mutant;) Daum 4.1` (a scraper bot) would be identified as IE and not have a version number. This would cause an [exception](https://app.bugsnag.com/shopify/shopify-checkout/errors/592f16f11899a600185b850f?event_id=592f16f11899a600185b850e&i=sk&m=nw).

This PR is fixing this by requiring the version number. In that case, this specific user agent wouldn't be identified as IE and it would fix the exception problem
