### PR TITLE
Include shopify user agents

### DIFF
--- a/browser_sniffer.gemspec
+++ b/browser_sniffer.gemspec
@@ -18,5 +18,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 1.9.3"
 
   spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "minitest"
   spec.add_development_dependency "rake"
 end

--- a/lib/browser_sniffer/patterns.rb
+++ b/lib/browser_sniffer/patterns.rb
@@ -45,6 +45,39 @@ class BrowserSniffer
   REGEX_MAP = {
     :browser => [
       [
+        # Shopify Mobile for iPhone or iPad
+        %r{^Shopify/\d+\s\((iPhone|iPad)\;\siOS\s[\d\.]+}i
+      ], [[:name, 'Shopify Mobile']], [
+        # Shopify Mobile for Android
+        %r{^Dalvik/[a-z0-9\.]+.*Shopify\s[\d+\.\/]+}i
+      ], [[:name, 'Shopify Mobile']], [
+        # Shopify POS for iOS
+        %r{.*(Shopify\sPOS)\/([\d\.]+)\s\((iPhone|iPad|iPod\stouch)\;}i,
+      ], [:name, :version], [
+        # Old Shopify POS for Android
+        %r{^Dalvik/[a-z0-9\.]+.*(Shopify\sPOS)\s(\d(?:\.\d+)*)(\/\d*)*}i,
+      ], [:name, :version], [
+        # Shopify POS for Android (Native App)
+        %r{.*(\sPOS\s-).*\s([\d+\.]+)(\/\d*)*\s}i,
+      ], [[:name, 'Shopify POS'], :version], [
+        # Shopify POS for Android (SmartWebView)
+        %r{.*(Shopify\sPOS)\s.*Android.*\s([\d+\.]+)(\/\d*)*\s}i,
+      ], [:name, :version], [
+        # Shopify POS uses this user agent
+        %r{^(okhttp)\/([\d\.]+)}i
+      ], [:name, :version], [
+        # Shopify Mobile for iPhone or iPad
+        %r{^(Shopify Mobile)\/(?:iPhone\sOS|iOS)\/([\d\.]+) \((iPhone|iPad|iPod)}i
+      ], [[:name, 'Shopify Mobile'], :version], [
+        # Shopify Mobile for Android
+        %r{^(Shopify Mobile)\/Android\/([\d\.]+(?: \(debug(?:|-push)\))?) \(Build (\d+) with API (\d+)}i
+      ], [[:name, 'Shopify Mobile'], :version, :build, :sdk_version], [
+        # ShopifyFoundation shared library
+        /^(ShopifyFoundation)/i,
+      ], [:name], [
+        # Shopify Ping iOS
+        %r{^(Shopify Ping)\/(?:iPhone\sOS|iOS)\/([\d\.]+) \((iPhone|iPad|iPod)}i
+      ], [[:name, 'Shopify Ping'], :version], [
         # Presto based
         /(opera\smini)\/((\d+)?[\w\.-]+)/i, # Opera Mini
         /(opera\s[mobiletab]+).+:version\/((\d+)?[\w\.-]+)/i, # Opera Mobi/Tablet
@@ -117,6 +150,36 @@ class BrowserSniffer
     ],
     :device => [
       [
+        # Shopify Mobile for iPhone
+        %r{^Shopify Mobile/(?:iPhone\sOS|iOS)/[\d\.]+ \((iPhone)([\d,]+)}i
+      ], [[:type, :handheld], :model], [
+        # Shopify Mobile for iPad
+        %r{^Shopify Mobile/(?:iPhone\sOS|iOS)/[\d\.]+ \((iPad)([\d,]+)}i
+      ], [[:type, :tablet], :model], [
+        # Shopify Mobile for iPod touch
+        %r{^Shopify Mobile/(?:iPhone\sOS|iOS)/[\d\.]+ \((iPod)([\d,]+)}i
+      ], [[:type, :handheld], :model], [
+        # Shopify Ping for iPhone
+        %r{^Shopify Ping/(?:iPhone\sOS|iOS)/[\d\.]+ \((iPhone)([\d,]+)}i
+      ], [[:type, :handheld], :model], [
+        # Shopify Mobile for Android
+        %r{^Shopify Mobile\/(Android)\/[\d\.]+(?: \(debug(?:|-push)\))? \(Build \d+ with API \d+ on (.*?) (.*)\)}i
+      ], [[:type, :handheld], :vendor, :model], [
+        # Shopify POS for iPhone
+        %r{.*Shopify POS\/[\d\.]+ \((iPhone)\;.*Scale/([\d\.]+)}i,
+      ], [[:type, :handheld], :scale], [
+        # Shopify POS for iPad
+        %r{.*Shopify POS\/[\d\.]+ \((iPad)\;.*Scale/([\d\.]+)}i,
+      ], [[:type, :tablet], :scale], [
+        # Shopify POS for iPod touch
+        %r{.*Shopify POS\/[\d\.]+ \((iPod touch)\;.*Scale/([\d\.]+)}i,
+      ], [[:type, :handheld], :scale], [
+        # Shopify POS for Android (SmartWebView)
+        %r{.*Shopify\sPOS.*\(.*(Android)\s[\d\.]+\;\s(.*)\sBuild/.*\)\sPOS.*[\d+\.]+}i,
+      ], [[:type, :handheld], :model], [
+        # Shopify POS for Android (Native App)
+        %r{.*\(.*(Android)\s[\d\.]+\;\s(.*)\sBuild/.*\)\sPOS.*[\d+\.]+}i,
+      ], [[:type, :handheld], :model], [
         /\((playbook);[\w\s\);-]+(rim)/i # PlayBook
       ], [:model, :vendor, [:type, :tablet]], [
         /\((ipad);[\w\s\);-]+(apple)/i # iPad
@@ -198,6 +261,30 @@ class BrowserSniffer
     ],
     :os => [
       [
+        # Shopify Mobile for iOS
+        %r{^Shopify/\d+\s\((?:iPhone|iPad)\;\s(iOS)\s([\d\.]+)}i
+      ], [[:type, :ios], :version, [:name, 'iOS']], [
+        # Shopify POS for iOS
+        %r{.*Shopify\sPOS/[\d\.]+\s\((?:iPhone|iPad|iPod\stouch)\;\s(iOS)\s([\d\.]+)}i,
+      ], [[:type, :ios], :version, [:name, 'iOS']], [
+        # Old Shopify POS for Android
+        /^Dalvik.*(Android)\s([\d\.]+)\;\s.*\s[\d+\.]+/i,
+      ], [[:type, :android], :version, [:name, 'Android']], [
+        # Shopify POS for Android
+        /.*Shopify\sPOS\s.*(Android)\s([\d\.]+)\;\s.*\s[\d+\.]+\s/i,
+      ], [[:type, :android], :version, [:name, 'Android']], [
+        # Shopify Mobile for iOS
+        %r{^Shopify Mobile\/(iPhone\sOS|iOS)\/[\d\.]+ \(.*\/OperatingSystemVersion\((.*)\)}i
+      ], [[:type, :ios], [:version, lambda { |str| str && str.scan(/\d+/).join(".") }], [:name, 'iOS']], [
+        # Shopify Mobile for iPhone or iPad
+        %r{^(Shopify Mobile)\/(?:iPhone\sOS|iOS)[\/\d\.]* \((iPhone|iPad|iPod).*\/([\d\.]+)}i
+      ], [[:type, :ios], [:name, 'iOS'], :version], [
+        # Shopify Ping for iOS
+        %r{^Shopify Ping\/(iOS)\/[\d\.]+ \(.* Simulator\/.*\/([\d\.]+)\)}i
+      ], [[:type, :ios], :version, [:name, 'iOS']], [
+        # Shopify Mobile for Android
+        %r{^Shopify Mobile\/(Android)\/[\d\.]+ }i
+      ], [:name, [:type, :android]], [
         # Windows based
         /(windows)\snt\s6\.2;\s(arm)/i, # Windows RT
         /(windows\sphone(?:\sos)*|windows\smobile|windows)[\s\/]?([ntce\d\.\s]+\w)/i,

--- a/lib/browser_sniffer/version.rb
+++ b/lib/browser_sniffer/version.rb
@@ -1,3 +1,3 @@
 class BrowserSniffer
-  VERSION = "1.0.13"
+  VERSION = "1.1.0"
 end

--- a/test/browser_sniffer_test.rb
+++ b/test/browser_sniffer_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class BrowserSnifferTest < MiniTest::Unit::TestCase
+class BrowserSnifferTest < Minitest::Test
   AGENTS = {
     :ipad_old => {
       :user_agent => "Mozilla/5.0(iPad; U; CPU iPhone OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B314 Safari/531.21.10",
@@ -221,7 +221,6 @@ class BrowserSnifferTest < MiniTest::Unit::TestCase
       :major_engine_version => 528,
       :os => :android,
       :os_version => '1.6',
-      :os => :android,
       :major_browser_version => 3
     },
     :hp_ipaq => {
@@ -552,7 +551,11 @@ class BrowserSnifferTest < MiniTest::Unit::TestCase
     define_method "test_sniff_#{agent}_correctly" do
       sniffer = BrowserSniffer.new(attributes[:user_agent])
       attributes.reject{|attr| attr == :user_agent}.each do |attribute, value|
-        assert_equal value, sniffer.send(attribute), "#{attribute.to_s} did not match"
+        if value.nil?
+          assert_nil sniffer.send(attribute), "#{attribute.to_s} did not match"
+        else
+          assert_equal value, sniffer.send(attribute), "#{attribute.to_s} did not match"
+        end
       end
     end
   end

--- a/test/shopify_agents_test.rb
+++ b/test/shopify_agents_test.rb
@@ -1,0 +1,365 @@
+require "test_helper"
+
+describe "Shopify agents" do
+  it "Shopify Mobile on iOS can be sniffed" do
+    user_agent = "Shopify Mobile/iOS/5.4.4 "\
+      "(iPhone9,3/com.jadedpixel.shopify/OperatingSystemVersion(majorVersion: 10, minorVersion: 3, patchVersion: 2))"
+    sniffer = BrowserSniffer.new(user_agent)
+
+    assert_equal ({
+      name: 'Shopify Mobile',
+      version: '5.4.4',
+    }), sniffer.browser_info
+
+    assert_equal ({
+      type: :handheld,
+      model: '9,3',
+    }), sniffer.device_info
+
+    assert_equal ({
+      type: :ios,
+      version: '10.3.2',
+      name: 'iOS',
+    }), sniffer.os_info
+  end
+
+  it "Shopify Mobile on iPod touch can be sniffed" do
+    user_agent = "Shopify Mobile/iPhone OS/5.4.4 "\
+      "(iPod5,1/com.jadedpixel.shopify/OperatingSystemVersion(majorVersion: 9, minorVersion: 3, patchVersion: 5))"
+    sniffer = BrowserSniffer.new(user_agent)
+
+    assert_equal ({
+      name: 'Shopify Mobile',
+      version: '5.4.4',
+    }), sniffer.browser_info
+
+    assert_equal ({
+      type: :handheld,
+      model: '5,1',
+    }), sniffer.device_info
+
+    assert_equal ({
+      type: :ios,
+      version: '9.3.5',
+      name: 'iOS',
+    }), sniffer.os_info
+  end
+
+  it "Shopify Mobile on iPhone is detected as handheld" do
+    user_agent = "Shopify Mobile/iOS/5.4.4 "\
+      "(iPhone9,3/com.jadedpixel.shopify/OperatingSystemVersion(majorVersion: 10, minorVersion: 3, patchVersion: 2))"
+    sniffer = BrowserSniffer.new(user_agent)
+    assert_equal :handheld, sniffer.form_factor
+    assert sniffer.handheld?
+  end
+
+  it "Shopify Mobile on iPad is detected as tablet" do
+    user_agent = "Shopify Mobile/iOS/5.4.4 "\
+      "(iPad9,3/com.jadedpixel.shopify/OperatingSystemVersion(majorVersion: 10, minorVersion: 3, patchVersion: 2))"
+    sniffer = BrowserSniffer.new(user_agent)
+    assert_equal :tablet, sniffer.form_factor
+    assert sniffer.tablet?
+  end
+
+  it "Shopify Mobile on iPhone OS is detected as iOS" do
+    user_agent = "Shopify Mobile/iPhone OS/5.4.4 "\
+      "(iPad2,4/com.jadedpixel.shopify/OperatingSystemVersion(majorVersion: 9, minorVersion: 3, patchVersion: 5))"
+    sniffer = BrowserSniffer.new(user_agent)
+    assert_equal :ios, sniffer.os
+    assert sniffer.ios?
+  end
+
+  it "Shopify Mobile version is delected on iPhone OS" do
+    user_agent = "Shopify Mobile/iOS/6.6.2 (iPhone10,1/com.jadedpixel.shopify/11.0.2)"
+    sniffer = BrowserSniffer.new(user_agent)
+    assert_equal "6.6.2", sniffer.browser_version
+    assert_equal "11.0.2", sniffer.os_version
+    assert sniffer.ios?
+  end
+
+  it "Shopify Mobile on Android can be sniffed" do
+    user_agent = "Shopify Mobile/Android/5.4.4 (Build 12005 with API 25 on OnePlus ONEPLUS A3003)"
+    sniffer = BrowserSniffer.new(user_agent)
+
+    assert_equal ({
+      name: 'Shopify Mobile',
+      version: '5.4.4',
+      build: '12005',
+      sdk_version: '25',
+    }), sniffer.browser_info
+
+    assert_equal ({
+      type: :handheld,
+      vendor: 'OnePlus',
+      model: 'ONEPLUS A3003',
+    }), sniffer.device_info
+
+    assert_equal ({
+      name: 'Android',
+      type: :android,
+    }), sniffer.os_info
+  end
+
+  it "Shopify Mobile on Android simulator can be sniffed" do
+    user_agent = "Shopify Mobile/Android/6.2.0 "\
+    "(debug) (Build 1 with API 25 on Unknown Android "\
+    "SDK built for x86) Mozilla/5.0 (Linux; Android 7.1.1; Android SDK built for x86 Build/NYC; wv) "\
+    "AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/55.0.2883.91 Mobile Safari/537.36"
+    sniffer = BrowserSniffer.new(user_agent)
+
+    assert_equal ({
+      name: 'Shopify Mobile',
+      version: '6.2.0 (debug)',
+      build: '1',
+      sdk_version: '25',
+    }), sniffer.browser_info
+
+    assert_equal ({
+      name: 'Android',
+      type: :android,
+    }), sniffer.os_info
+  end
+
+  it "Shopify POS on Android MAL can be sniffed" do
+    user_agent = "Dalvik/2.1.0 (Linux; U; Android 7.1.1; Android SDK built for x86 Build/NYC) "\
+    "Shopify POS 2.4.11.mal/18038"
+    sniffer = BrowserSniffer.new(user_agent)
+
+    assert_equal ({
+      name: 'Shopify POS',
+      version: '2.4.11',
+    }), sniffer.browser_info
+
+    assert_equal ({
+      name: 'Android',
+      type: :android,
+      version: '7.1.1',
+    }), sniffer.os_info
+  end
+
+  it "Shopify POS on iPhone can be sniffed" do
+    user_agent = "Shopify POS/3.12.1 (iPhone; iOS 10.3.1; Scale/2.00)"
+    sniffer = BrowserSniffer.new(user_agent)
+
+    assert_equal ({
+      name: 'Shopify POS',
+      version: '3.12.1',
+    }), sniffer.browser_info
+
+    assert_equal ({
+      type: :handheld,
+      scale: '2.00',
+    }), sniffer.device_info
+
+    assert_equal ({
+      type: :ios,
+      version: '10.3.1',
+      name: 'iOS',
+    }), sniffer.os_info
+  end
+
+  it "Shopify POS on iPod touch can be sniffed" do
+    user_agent = "Shopify POS/3.12.1 (iPod touch; iOS 9.3.5; Scale/2.00)"
+    sniffer = BrowserSniffer.new(user_agent)
+
+    assert_equal ({
+      name: 'Shopify POS',
+      version: '3.12.1',
+    }), sniffer.browser_info
+
+    assert_equal ({
+      type: :handheld,
+      scale: '2.00',
+    }), sniffer.device_info
+
+    assert_equal ({
+      type: :ios,
+      version: '9.3.5',
+      name: 'iOS',
+    }), sniffer.os_info
+  end
+
+  it "Shopify POS on iPad is detected as tablet" do
+    user_agent = "Shopify POS/3.10.12 (iPad; iOS 10.3.1; Scale/2.00)"
+    sniffer = BrowserSniffer.new(user_agent)
+
+    assert_equal :tablet, sniffer.form_factor
+  end
+
+  it "Shopify POS with okhttp user agent can be parsed" do
+    user_agent = "okhttp/3.6.0"
+    sniffer = BrowserSniffer.new(user_agent)
+
+    assert_equal ({
+      name: 'okhttp',
+      version: '3.6.0',
+    }), sniffer.browser_info
+  end
+
+  it "Shopify POS on Android can be sniffed (SmartWebView)" do
+    user_agent = "com.jadedpixel.pos Shopify POS Dalvik/2.1.0 (Linux; U; Android 7.1.1; " \
+    "SM-T560NU Build/NMF26X) POS - Debug 2.4.10 (1a5a407d00)/3405  Mozilla/5.0 " \
+    "(Linux; Android 7.1.1; SM-T560NU Build/NMF26X; wv) AppleWebKit/537.36 " \
+    "(KHTML, like Gecko) Version/4.0 Chrome/67.0.3396.87 Safari/537.36"
+    sniffer = BrowserSniffer.new(user_agent)
+
+    user_agent_with_suffix = "com.jadedpixel.pos Shopify POS Dalvik/2.1.0 (Linux; U; Android 7.1.1; " \
+    "SM-T560NU Build/NMF26X) POS - Debug 2.4.10/1337 (1a5a407d00)/3405  Mozilla/5.0 " \
+    "(Linux; Android 7.1.1; SM-T560NU Build/NMF26X; wv) AppleWebKit/537.36 " \
+    "(KHTML, like Gecko) Version/4.0 Chrome/67.0.3396.87 Safari/537.36"
+    sniffer_with_suffix = BrowserSniffer.new(user_agent_with_suffix)
+
+    assert_equal ({
+      name: 'Shopify POS',
+      version: '2.4.10',
+    }), sniffer.browser_info
+
+    assert_equal ({
+      type: :handheld,
+      model: 'SM-T560NU',
+    }), sniffer.device_info
+
+    assert_equal ({
+      type: :android,
+      version: '7.1.1',
+      name: 'Android',
+    }), sniffer.os_info
+
+    assert_equal sniffer.browser_info, sniffer_with_suffix.browser_info
+    assert_equal sniffer.device_info, sniffer_with_suffix.device_info
+    assert_equal sniffer.os_info, sniffer_with_suffix.os_info
+  end
+
+  it "Shopify POS on Android can be sniffed (Native App)" do
+    user_agent = "Dalvik/2.1.0 (Linux; U; Android 7.1.1; SM-T560NU Build/NMF26X) " \
+    "POS - Debug 2.4.10 (1a5a407d00)/3405"
+    sniffer = BrowserSniffer.new(user_agent)
+
+    user_agent_with_suffix = "Dalvik/2.1.0 (Linux; U; Android 7.1.1; SM-T560NU Build/NMF26X) " \
+    "POS - Debug 2.4.10/1337 (1a5a407d00)/3405"
+    sniffer_with_suffix = BrowserSniffer.new(user_agent_with_suffix)
+
+    assert_equal ({
+      name: 'Shopify POS',
+      version: '2.4.10',
+    }), sniffer.browser_info
+
+    assert_equal ({
+      type: :handheld,
+      model: 'SM-T560NU',
+    }), sniffer.device_info
+
+    assert_equal ({
+      type: :android,
+      version: '7.1.1',
+      name: 'Android',
+    }), sniffer.os_info
+
+    assert_equal sniffer.browser_info, sniffer_with_suffix.browser_info
+    assert_equal sniffer.device_info, sniffer_with_suffix.device_info
+    assert_equal sniffer.os_info, sniffer_with_suffix.os_info
+  end
+
+  it "Shopify Mobile in debug mode can be parsed" do
+    user_agent = "Shopify Mobile/Android/6.0.0 (debug) (Build 1 with API 25 on Unknown Android SDK built for x86)"
+    sniffer = BrowserSniffer.new(user_agent)
+
+    assert_equal ({
+      name: 'Shopify Mobile',
+      version: '6.0.0 (debug)',
+      build: '1',
+      sdk_version: '25',
+    }), sniffer.browser_info
+
+    assert_equal ({
+      type: :handheld,
+      vendor: 'Unknown',
+      model: 'Android SDK built for x86',
+    }), sniffer.device_info
+
+    assert_equal ({
+      name: 'Android',
+      type: :android,
+    }), sniffer.os_info
+  end
+
+  it "Shopify Mobile in debug-push mode can be parsed" do
+    user_agent = "Shopify Mobile/Android/6.0.0 (debug-push) (Build 1 with API 25 on Unknown Android SDK built for x86)"
+    sniffer = BrowserSniffer.new(user_agent)
+
+    assert_equal ({
+      name: 'Shopify Mobile',
+      version: '6.0.0 (debug-push)',
+      build: '1',
+      sdk_version: '25',
+    }), sniffer.browser_info
+
+    assert_equal ({
+      type: :handheld,
+      vendor: 'Unknown',
+      model: 'Android SDK built for x86',
+    }), sniffer.device_info
+
+    assert_equal ({
+      name: 'Android',
+      type: :android,
+    }), sniffer.os_info
+  end
+
+  it "ShopifyFoundation user agent can be parsed" do
+    user_agent = "ShopifyFoundation"
+    sniffer = BrowserSniffer.new(user_agent)
+
+    assert_equal ({ name: 'ShopifyFoundation' }), sniffer.browser_info
+    assert_predicate sniffer.device_info, :empty?
+    assert_predicate sniffer.os_info, :empty?
+  end
+
+  it "old Shopify POS user agent can be parsed" do
+    user_agent = "Dalvik/2.1.0 (Linux; U; Android 5.1; KUAIKABAO/R5100 Build/LMY47I) Shopify POS 0.9.4"
+    sniffer = BrowserSniffer.new(user_agent)
+
+    user_agent_with_suffix = "Dalvik/2.1.0 (Linux; U; Android 5.1; KUAIKABAO/R5100 Build/LMY47I) Shopify POS 0.9.4/7"
+    sniffer_with_suffix = BrowserSniffer.new(user_agent_with_suffix)
+
+    assert_equal ({
+      name: 'Shopify POS',
+      version: '0.9.4',
+    }), sniffer.browser_info
+
+    assert_equal ({
+      type: :handheld,
+    }), sniffer.device_info
+
+    assert_equal ({
+      name: 'Android',
+      type: :android,
+      version: '5.1',
+    }), sniffer.os_info
+
+    assert_equal sniffer.browser_info, sniffer_with_suffix.browser_info
+    assert_equal sniffer.device_info, sniffer_with_suffix.device_info
+    assert_equal sniffer.os_info, sniffer_with_suffix.os_info
+  end
+
+  it "Shopify Ping on iOS can be sniffed" do
+    user_agent = "Shopify Ping/iOS/1.0.0 (iPhone9,1 Simulator/com.shopify.ping/11.1.0)"
+    sniffer = BrowserSniffer.new(user_agent)
+
+    assert_equal ({
+      name: 'Shopify Ping',
+      version: '1.0.0',
+    }), sniffer.browser_info
+
+    assert_equal ({
+      type: :handheld,
+      model: '9,1',
+    }), sniffer.device_info
+
+    assert_equal ({
+      type: :ios,
+      version: '11.1.0',
+      name: 'iOS',
+    }), sniffer.os_info
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,4 @@
 require 'rubygems'
-require 'test/unit'
+require 'minitest/autorun'
 
 require "#{File.dirname(__FILE__)}/../init"
-


### PR DESCRIPTION
We need to share logic to match against Shopify user agents to public gems. This allow us to do so.