### PR TITLE
Fix Ping user agent OS

### DIFF
--- a/browser_sniffer.gemspec
+++ b/browser_sniffer.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 1.9.3"
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "rake"
 end

--- a/lib/browser_sniffer/patterns.rb
+++ b/lib/browser_sniffer/patterns.rb
@@ -280,7 +280,7 @@ class BrowserSniffer
         %r{^(Shopify Mobile)\/(?:iPhone\sOS|iOS)[\/\d\.]* \((iPhone|iPad|iPod).*\/([\d\.]+)}i
       ], [[:type, :ios], [:name, 'iOS'], :version], [
         # Shopify Ping for iOS
-        %r{^Shopify Ping\/(iOS)\/[\d\.]+ \(.* Simulator\/.*\/([\d\.]+)\)}i
+        %r{^Shopify Ping\/(iOS)\/[\d\.]+ \(.*\/([\d\.]+)\)}i
       ], [[:type, :ios], :version, [:name, 'iOS']], [
         # Shopify Mobile for Android
         %r{^Shopify Mobile\/(Android)\/[\d\.]+ }i

--- a/lib/browser_sniffer/version.rb
+++ b/lib/browser_sniffer/version.rb
@@ -1,3 +1,3 @@
 class BrowserSniffer
-  VERSION = "1.1.0"
+  VERSION = "1.1.1"
 end

--- a/test/shopify_agents_test.rb
+++ b/test/shopify_agents_test.rb
@@ -342,8 +342,29 @@ describe "Shopify agents" do
     assert_equal sniffer.os_info, sniffer_with_suffix.os_info
   end
 
-  it "Shopify Ping on iOS can be sniffed" do
+  it "Shopify Ping on iOS simulator can be sniffed" do
     user_agent = "Shopify Ping/iOS/1.0.0 (iPhone9,1 Simulator/com.shopify.ping/11.1.0)"
+    sniffer = BrowserSniffer.new(user_agent)
+
+    assert_equal ({
+      name: 'Shopify Ping',
+      version: '1.0.0',
+    }), sniffer.browser_info
+
+    assert_equal ({
+      type: :handheld,
+      model: '9,1',
+    }), sniffer.device_info
+
+    assert_equal ({
+      type: :ios,
+      version: '11.1.0',
+      name: 'iOS',
+    }), sniffer.os_info
+  end
+
+  it "Shopify Ping on iOS can be sniffed" do
+    user_agent = "Shopify Ping/iOS/1.0.0 (iPhone9,1/com.jadedlabs.ping/11.1.0)"
     sniffer = BrowserSniffer.new(user_agent)
 
     assert_equal ({


### PR DESCRIPTION
Fixes detecting the OS for Ping clients. Before the change, browser_sniffer would return nothing if Ping was not running in a simulator.