### PR TITLE
Update Shopify Mobile user agent pattern

### DIFF
--- a/lib/browser_sniffer/patterns.rb
+++ b/lib/browser_sniffer/patterns.rb
@@ -46,10 +46,10 @@ class BrowserSniffer
     :browser => [
       [
         # Shopify Mobile for iPhone or iPad
-        %r{^Shopify/\d+\s\((iPhone|iPad)\;\siOS\s[\d\.]+}i
+        %r{.*Shopify/\d+\s\((iPhone|iPad)\;\siOS\s[\d\.]+}i
       ], [[:name, 'Shopify Mobile']], [
         # Shopify Mobile for Android
-        %r{^Dalvik/[a-z0-9\.]+.*Shopify\s[\d+\.\/]+}i
+        %r{.*Dalvik/[a-z0-9\.]+.*Shopify\s[\d+\.\/]+}i
       ], [[:name, 'Shopify Mobile']], [
         # Shopify POS for iOS
         %r{.*(Shopify\sPOS)\/([\d\.]+)\s\((iPhone|iPad|iPod\stouch)\;}i,
@@ -67,16 +67,16 @@ class BrowserSniffer
         %r{^(okhttp)\/([\d\.]+)}i
       ], [:name, :version], [
         # Shopify Mobile for iPhone or iPad
-        %r{^(Shopify Mobile)\/(?:iPhone\sOS|iOS)\/([\d\.]+) \((iPhone|iPad|iPod)}i
+        %r{.*(Shopify Mobile)\/(?:iPhone\sOS|iOS)\/([\d\.]+) \((iPhone|iPad|iPod)}i
       ], [[:name, 'Shopify Mobile'], :version], [
         # Shopify Mobile for Android
-        %r{^(Shopify Mobile)\/Android\/([\d\.]+(?: \(debug(?:|-push)\))?) \(Build (\d+) with API (\d+)}i
+        %r{.*(Shopify Mobile)\/Android\/([\d\.]+(?: \(debug(?:|-push)\))?) \(Build (\d+) with API (\d+)}i
       ], [[:name, 'Shopify Mobile'], :version, :build, :sdk_version], [
         # ShopifyFoundation shared library
         /^(ShopifyFoundation)/i,
       ], [:name], [
         # Shopify Ping iOS
-        %r{^(Shopify Ping)\/(?:iPhone\sOS|iOS)\/([\d\.]+) \((iPhone|iPad|iPod)}i
+        %r{.*(Shopify Ping)\/(?:iPhone\sOS|iOS)\/([\d\.]+) \((iPhone|iPad|iPod)}i
       ], [[:name, 'Shopify Ping'], :version], [
         # Presto based
         /(opera\smini)\/((\d+)?[\w\.-]+)/i, # Opera Mini
@@ -151,19 +151,19 @@ class BrowserSniffer
     :device => [
       [
         # Shopify Mobile for iPhone
-        %r{^Shopify Mobile/(?:iPhone\sOS|iOS)/[\d\.]+ \((iPhone)([\d,]+)}i
+        %r{.*Shopify Mobile/(?:iPhone\sOS|iOS)/[\d\.]+ \((iPhone)([\d,]+)}i
       ], [[:type, :handheld], :model], [
         # Shopify Mobile for iPad
-        %r{^Shopify Mobile/(?:iPhone\sOS|iOS)/[\d\.]+ \((iPad)([\d,]+)}i
+        %r{.*Shopify Mobile/(?:iPhone\sOS|iOS)/[\d\.]+ \((iPad)([\d,]+)}i
       ], [[:type, :tablet], :model], [
         # Shopify Mobile for iPod touch
-        %r{^Shopify Mobile/(?:iPhone\sOS|iOS)/[\d\.]+ \((iPod)([\d,]+)}i
+        %r{.*Shopify Mobile/(?:iPhone\sOS|iOS)/[\d\.]+ \((iPod)([\d,]+)}i
       ], [[:type, :handheld], :model], [
         # Shopify Ping for iPhone
-        %r{^Shopify Ping/(?:iPhone\sOS|iOS)/[\d\.]+ \((iPhone)([\d,]+)}i
+        %r{.*Shopify Ping/(?:iPhone\sOS|iOS)/[\d\.]+ \((iPhone)([\d,]+)}i
       ], [[:type, :handheld], :model], [
         # Shopify Mobile for Android
-        %r{^Shopify Mobile\/(Android)\/[\d\.]+(?: \(debug(?:|-push)\))? \(Build \d+ with API \d+ on (.*?) (.*)\)}i
+        %r{.*Shopify Mobile\/(Android)\/[\d\.]+(?: \(debug(?:|-push)\))? \(Build \d+ with API \d+ on (.*?) ([^\)]*)\)}i
       ], [[:type, :handheld], :vendor, :model], [
         # Shopify POS for iPhone
         %r{.*Shopify POS\/[\d\.]+ \((iPhone)\;.*Scale/([\d\.]+)}i,
@@ -262,7 +262,7 @@ class BrowserSniffer
     :os => [
       [
         # Shopify Mobile for iOS
-        %r{^Shopify/\d+\s\((?:iPhone|iPad)\;\s(iOS)\s([\d\.]+)}i
+        %r{.*Shopify/\d+\s\((?:iPhone|iPad)\;\s(iOS)\s([\d\.]+)}i
       ], [[:type, :ios], :version, [:name, 'iOS']], [
         # Shopify POS for iOS
         %r{.*Shopify\sPOS/[\d\.]+\s\((?:iPhone|iPad|iPod\stouch)\;\s(iOS)\s([\d\.]+)}i,
@@ -274,16 +274,16 @@ class BrowserSniffer
         /.*Shopify\sPOS\s.*(Android)\s([\d\.]+)\;\s.*\s[\d+\.]+\s/i,
       ], [[:type, :android], :version, [:name, 'Android']], [
         # Shopify Mobile for iOS
-        %r{^Shopify Mobile\/(iPhone\sOS|iOS)\/[\d\.]+ \(.*\/OperatingSystemVersion\((.*)\)}i
+        %r{.*Shopify Mobile\/(iPhone\sOS|iOS)\/[\d\.]+ \(.*\/OperatingSystemVersion\((.*)\)}i
       ], [[:type, :ios], [:version, lambda { |str| str && str.scan(/\d+/).join(".") }], [:name, 'iOS']], [
         # Shopify Mobile for iPhone or iPad
-        %r{^(Shopify Mobile)\/(?:iPhone\sOS|iOS)[\/\d\.]* \((iPhone|iPad|iPod).*\/([\d\.]+)}i
+        %r{.*(Shopify Mobile)\/(?:iPhone\sOS|iOS)[\/\d\.]* \((iPhone|iPad|iPod).*\/([\d\.]+)\)}i
       ], [[:type, :ios], [:name, 'iOS'], :version], [
         # Shopify Ping for iOS
-        %r{^Shopify Ping\/(iOS)\/[\d\.]+ \(.*\/([\d\.]+)\)}i
+        %r{.*Shopify Ping\/(iOS)\/[\d\.]+ \(.*\/([\d\.]+)\)}i
       ], [[:type, :ios], :version, [:name, 'iOS']], [
         # Shopify Mobile for Android
-        %r{^Shopify Mobile\/(Android)\/[\d\.]+ }i
+        %r{.*Shopify Mobile\/(Android)\/[\d\.]+ }i
       ], [:name, [:type, :android]], [
         # Windows based
         /(windows)\snt\s6\.2;\s(arm)/i, # Windows RT

--- a/lib/browser_sniffer/version.rb
+++ b/lib/browser_sniffer/version.rb
@@ -1,3 +1,3 @@
 class BrowserSniffer
-  VERSION = "1.1.1"
+  VERSION = "1.1.2"
 end

--- a/test/shopify_agents_test.rb
+++ b/test/shopify_agents_test.rb
@@ -21,6 +21,27 @@ describe "Shopify agents" do
       version: '10.3.2',
       name: 'iOS',
     }), sniffer.os_info
+
+    user_agent = "Mozilla/5.0 (iPhone; CPU iPhone OS 12_0 like Mac OS X) "\
+    "AppleWebKit/ 604.1.21 (KHTML, like Gecko) Version/ 12.0 Mobile/17A6278a Safari/602.1.26 "\
+    "MobileMiddlewareSupported Shopify Mobile/iOS/8.12.0 (iPad4,7/com.shopify.ShopifyInternal/12.0.0)"
+    sniffer = BrowserSniffer.new(user_agent)
+
+    assert_equal ({
+      name: 'Shopify Mobile',
+      version: '8.12.0',
+    }), sniffer.browser_info
+
+    assert_equal ({
+      type: :tablet,
+      model: '4,7',
+    }), sniffer.device_info
+
+    assert_equal ({
+      type: :ios,
+      version: '12.0.0',
+      name: 'iOS',
+    }), sniffer.os_info
   end
 
   it "Shopify Mobile on iPod touch can be sniffed" do
@@ -43,11 +64,39 @@ describe "Shopify agents" do
       version: '9.3.5',
       name: 'iOS',
     }), sniffer.os_info
+
+    user_agent = "Mozilla/5.0 (iPhone; CPU iPhone OS 12_0 like Mac OS X) "\
+    "AppleWebKit/ 604.1.21 (KHTML, like Gecko) Version/ 12.0 Mobile/17A6278a Safari/602.1.26 "\
+    "MobileMiddlewareSupported Shopify Mobile/iOS/8.12.0 (iPod5,1/com.shopify.ShopifyInternal/12.0.0)"
+    sniffer = BrowserSniffer.new(user_agent)
+
+    assert_equal ({
+      name: 'Shopify Mobile',
+      version: '8.12.0',
+    }), sniffer.browser_info
+
+    assert_equal ({
+      type: :handheld,
+      model: '5,1',
+    }), sniffer.device_info
+
+    assert_equal ({
+      type: :ios,
+      version: '12.0.0',
+      name: 'iOS',
+    }), sniffer.os_info
   end
 
   it "Shopify Mobile on iPhone is detected as handheld" do
     user_agent = "Shopify Mobile/iOS/5.4.4 "\
       "(iPhone9,3/com.jadedpixel.shopify/OperatingSystemVersion(majorVersion: 10, minorVersion: 3, patchVersion: 2))"
+    sniffer = BrowserSniffer.new(user_agent)
+    assert_equal :handheld, sniffer.form_factor
+    assert sniffer.handheld?
+
+    user_agent = "Mozilla/5.0 (iPhone; CPU iPhone OS 12_0 like Mac OS X) "\
+    "AppleWebKit/ 604.1.21 (KHTML, like Gecko) Version/ 12.0 Mobile/17A6278a Safari/602.1.26 "\
+    "MobileMiddlewareSupported Shopify Mobile/iOS/8.12.0 (iPhone9,3/com.shopify.ShopifyInternal/12.0.0)"
     sniffer = BrowserSniffer.new(user_agent)
     assert_equal :handheld, sniffer.form_factor
     assert sniffer.handheld?
@@ -59,6 +108,13 @@ describe "Shopify agents" do
     sniffer = BrowserSniffer.new(user_agent)
     assert_equal :tablet, sniffer.form_factor
     assert sniffer.tablet?
+
+    user_agent = "Mozilla/5.0 (iPhone; CPU iPhone OS 12_0 like Mac OS X) "\
+    "AppleWebKit/ 604.1.21 (KHTML, like Gecko) Version/ 12.0 Mobile/17A6278a Safari/602.1.26 "\
+    "MobileMiddlewareSupported Shopify Mobile/iOS/8.12.0 (iPad9,3/com.shopify.ShopifyInternal/12.0.0)"
+    sniffer = BrowserSniffer.new(user_agent)
+    assert_equal :tablet, sniffer.form_factor
+    assert sniffer.tablet?
   end
 
   it "Shopify Mobile on iPhone OS is detected as iOS" do
@@ -67,10 +123,25 @@ describe "Shopify agents" do
     sniffer = BrowserSniffer.new(user_agent)
     assert_equal :ios, sniffer.os
     assert sniffer.ios?
+
+    user_agent = "Mozilla/5.0 (iPhone; CPU iPhone OS 12_0 like Mac OS X) "\
+    "AppleWebKit/ 604.1.21 (KHTML, like Gecko) Version/ 12.0 Mobile/17A6278a Safari/602.1.26 "\
+    "MobileMiddlewareSupported Shopify Mobile/iOS/8.12.0 (iPad9,3/com.shopify.ShopifyInternal/12.0.0)"
+    sniffer = BrowserSniffer.new(user_agent)
+    assert_equal :ios, sniffer.os
+    assert sniffer.ios?
   end
 
   it "Shopify Mobile version is delected on iPhone OS" do
     user_agent = "Shopify Mobile/iOS/6.6.2 (iPhone10,1/com.jadedpixel.shopify/11.0.2)"
+    sniffer = BrowserSniffer.new(user_agent)
+    assert_equal "6.6.2", sniffer.browser_version
+    assert_equal "11.0.2", sniffer.os_version
+    assert sniffer.ios?
+
+    user_agent = "Mozilla/5.0 (iPhone; CPU iPhone OS 12_0 like Mac OS X) "\
+    "AppleWebKit/ 604.1.21 (KHTML, like Gecko) Version/ 12.0 Mobile/17A6278a Safari/602.1.26 "\
+    "MobileMiddlewareSupported Shopify Mobile/iOS/6.6.2 (iPad9,3/com.shopify.ShopifyInternal/11.0.2)"
     sniffer = BrowserSniffer.new(user_agent)
     assert_equal "6.6.2", sniffer.browser_version
     assert_equal "11.0.2", sniffer.os_version
@@ -92,6 +163,29 @@ describe "Shopify agents" do
       type: :handheld,
       vendor: 'OnePlus',
       model: 'ONEPLUS A3003',
+    }), sniffer.device_info
+
+    assert_equal ({
+      name: 'Android',
+      type: :android,
+    }), sniffer.os_info
+
+    user_agent = "Shopify Mobile/Android/8.12.0 (Build 12005 with API 28 on Google Android SDK built for x86) "\
+    "MobileMiddlewareSupported Mozilla/5.0 (Linux; Android 9; Android SDK built for x86 Build/PSR1.180720.075; wv) "\
+    "AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/69.0.3497.100 Mobile Safari/537.36"
+    sniffer = BrowserSniffer.new(user_agent)
+    
+    assert_equal ({
+      name: 'Shopify Mobile',
+      version: '8.12.0',
+      build: '12005',
+      sdk_version: '28',
+    }), sniffer.browser_info
+
+    assert_equal ({
+      type: :handheld,
+      vendor: 'Google',
+      model: 'Android SDK built for x86',
     }), sniffer.device_info
 
     assert_equal ({


### PR DESCRIPTION
Update the Shopify Mobile user agent patterns since iOS has changed their user agent.

iOS looks like: `Mozilla/5.0 (iPhone; CPU iPhone OS 12_0 like Mac OS X) AppleWebKit/ 604.1.21 (KHTML, like Gecko) Version/ 12.0 Mobile/17A6278a Safari/602.1.26 MobileMiddlewareSupported Shopify Mobile/iOS/8.12.0 (iPad4,7/com.shopify.ShopifyInternal/12.0.0)`

Android looks like: `Shopify Mobile/Android/8.12.0 (debug) (Build 1 with API 28 on Google Android SDK built for x86) MobileMiddlewareSupported  Mozilla/5.0 (Linux; Android 9; Android SDK built for x86 Build/PSR1.180720.075; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/69.0.3497.100 Mobile Safari/537.36`

Just need sanity check on the regex patterns that were updated. It used to have `^Shopify Mobile...`, but this is no longer the case for iOS.