### PR TITLE
add regex patterns to match against user agents sent from POS Next

### DIFF
--- a/lib/browser_sniffer/patterns.rb
+++ b/lib/browser_sniffer/patterns.rb
@@ -69,6 +69,9 @@ class BrowserSniffer
         # Shopify Mobile for iPhone or iPad
         %r{.*(Shopify Mobile)\/(?:iPhone\sOS|iOS)\/([\d\.]+) \((iPhone|iPad|iPod)}i
       ], [[:name, 'Shopify Mobile'], :version], [
+        # Shopify POS Next for iPhone or iPad
+        %r{.*(Shopify POS Next|Shopify POS)\/(?:iOS)\/([\d\.]+) \((iPhone|iPad|iPod)}i
+      ], [[:name, 'Shopify POS'], :version], [
         # Shopify Mobile for Android
         %r{.*(Shopify Mobile)\/Android\/([\d\.]+(?: \(debug(?:|-push)\))?) \(Build (\d+) with API (\d+)}i
       ], [[:name, 'Shopify Mobile'], :version, :build, :sdk_version], [
@@ -158,6 +161,15 @@ class BrowserSniffer
       ], [[:type, :tablet], :model], [
         # Shopify Mobile for iPod touch
         %r{.*Shopify Mobile/(?:iPhone\sOS|iOS)/[\d\.]+ \((iPod)([\d,]+)}i
+      ], [[:type, :handheld], :model], [
+        # Shopify POS Next for iPhone
+        %r{.*(?:Shopify POS Next|Shopify POS)/(?:iPhone\sOS|iOS)/[\d\.]+ \((iPhone)([\d,]+)}i
+      ], [[:type, :handheld], :model], [
+        # Shopify POS Next for iPad
+        %r{.*(?:Shopify POS Next|Shopify POS)/(?:iPhone\sOS|iOS)/[\d\.]+ \((iPad)([\d,]+)}i
+      ], [[:type, :tablet], :model], [
+        # Shopify POS Next for iPod touch
+        %r{.*(?:Shopify POS Next|Shopify POS)/(?:iPhone\sOS|iOS)/[\d\.]+ \((iPod)([\d,]+)}i
       ], [[:type, :handheld], :model], [
         # Shopify Ping for iPhone
         %r{.*Shopify Ping/(?:iPhone\sOS|iOS)/[\d\.]+ \((iPhone)([\d,]+)}i
@@ -278,6 +290,9 @@ class BrowserSniffer
       ], [[:type, :ios], [:version, lambda { |str| str && str.scan(/\d+/).join(".") }], [:name, 'iOS']], [
         # Shopify Mobile for iPhone or iPad
         %r{.*(Shopify Mobile)\/(?:iPhone\sOS|iOS)[\/\d\.]* \((iPhone|iPad|iPod).*\/([\d\.]+)\)}i
+      ], [[:type, :ios], [:name, 'iOS'], :version], [
+        # Shopify POS Next for iPhone or iPad
+        %r{.*(Shopify POS Next|Shopify POS)\/(?:iPhone\sOS|iOS)[\/\d\.]* \((iPhone|iPad|iPod).*\/([\d\.]+)\)}i
       ], [[:type, :ios], [:name, 'iOS'], :version], [
         # Shopify Ping for iOS
         %r{.*Shopify Ping\/(iOS)\/[\d\.]+ \(.*\/([\d\.]+)\)}i

--- a/lib/browser_sniffer/version.rb
+++ b/lib/browser_sniffer/version.rb
@@ -1,3 +1,3 @@
 class BrowserSniffer
-  VERSION = "1.1.2"
+  VERSION = "1.1.3"
 end

--- a/test/shopify_agents_test.rb
+++ b/test/shopify_agents_test.rb
@@ -252,6 +252,48 @@ describe "Shopify agents" do
     }), sniffer.os_info
   end
 
+  it "Shopify POS on iPhone with modern user agent can be sniffed" do
+    user_agent = "Shopify POS/iOS/3.12.1 (iPhone10,2/com.jadedpixel.pos/10.3.1)"
+    sniffer = BrowserSniffer.new(user_agent)
+
+    assert_equal ({
+      name: 'Shopify POS',
+      version: '3.12.1',
+    }), sniffer.browser_info
+
+    assert_equal ({
+      type: :handheld,
+      model: '10,2',
+    }), sniffer.device_info
+
+    assert_equal ({
+      type: :ios,
+      version: '10.3.1',
+      name: 'iOS',
+    }), sniffer.os_info
+  end
+
+  it "Shopify POS Next on iPhone with modern user agent can be sniffed" do
+    user_agent = "Shopify POS Next/iOS/3.12.1 (iPhone10,2/com.jadedpixel.pos/10.3.1)"
+    sniffer = BrowserSniffer.new(user_agent)
+
+    assert_equal ({
+      name: 'Shopify POS',
+      version: '3.12.1',
+    }), sniffer.browser_info
+
+    assert_equal ({
+      type: :handheld,
+      model: '10,2',
+    }), sniffer.device_info
+
+    assert_equal ({
+      type: :ios,
+      version: '10.3.1',
+      name: 'iOS',
+    }), sniffer.os_info
+  end
+
   it "Shopify POS on iPod touch can be sniffed" do
     user_agent = "Shopify POS/3.12.1 (iPod touch; iOS 9.3.5; Scale/2.00)"
     sniffer = BrowserSniffer.new(user_agent)
@@ -273,11 +315,95 @@ describe "Shopify agents" do
     }), sniffer.os_info
   end
 
+  it "Shopify POS on iPod touch with modern user agent can be sniffed" do
+    user_agent = "Shopify POS/iOS/3.12.1 (iPod5,2/com.jadedpixel.pos/10.3.1)"
+    sniffer = BrowserSniffer.new(user_agent)
+
+    assert_equal ({
+      name: 'Shopify POS',
+      version: '3.12.1',
+    }), sniffer.browser_info
+
+    assert_equal ({
+      type: :handheld,
+      model: '5,2',
+    }), sniffer.device_info
+
+    assert_equal ({
+      type: :ios,
+      version: '10.3.1',
+      name: 'iOS',
+    }), sniffer.os_info
+  end
+
+  it "Shopify POS Next on iPod touch with modern user agent can be sniffed" do
+    user_agent = "Shopify POS Next/iOS/3.12.1 (iPod5,2/com.jadedpixel.pos/10.3.1)"
+    sniffer = BrowserSniffer.new(user_agent)
+
+    assert_equal ({
+      name: 'Shopify POS',
+      version: '3.12.1',
+    }), sniffer.browser_info
+
+    assert_equal ({
+      type: :handheld,
+      model: '5,2',
+    }), sniffer.device_info
+
+    assert_equal ({
+      type: :ios,
+      version: '10.3.1',
+      name: 'iOS',
+    }), sniffer.os_info
+  end
+
   it "Shopify POS on iPad is detected as tablet" do
     user_agent = "Shopify POS/3.10.12 (iPad; iOS 10.3.1; Scale/2.00)"
     sniffer = BrowserSniffer.new(user_agent)
 
     assert_equal :tablet, sniffer.form_factor
+  end
+
+  it "Shopify POS on iPad with modern user agent can be sniffed" do
+    user_agent = "Shopify POS/iOS/3.12.1 (iPad4,7/com.jadedpixel.pos/10.3.1)"
+    sniffer = BrowserSniffer.new(user_agent)
+
+    assert_equal ({
+      name: 'Shopify POS',
+      version: '3.12.1',
+    }), sniffer.browser_info
+
+    assert_equal ({
+      type: :tablet,
+      model: '4,7',
+    }), sniffer.device_info
+
+    assert_equal ({
+      type: :ios,
+      version: '10.3.1',
+      name: 'iOS',
+    }), sniffer.os_info
+  end
+
+  it "Shopify POS Next on iPad with modern user agent can be sniffed" do
+    user_agent = "Shopify POS Next/iOS/3.12.1 (iPad4,7/com.jadedpixel.pos/10.3.1)"
+    sniffer = BrowserSniffer.new(user_agent)
+
+    assert_equal ({
+      name: 'Shopify POS',
+      version: '3.12.1',
+    }), sniffer.browser_info
+
+    assert_equal ({
+      type: :tablet,
+      model: '4,7',
+    }), sniffer.device_info
+
+    assert_equal ({
+      type: :ios,
+      version: '10.3.1',
+      name: 'iOS',
+    }), sniffer.os_info
   end
 
   it "Shopify POS with okhttp user agent can be parsed" do


### PR DESCRIPTION
POS Next is sending its user agent string in the same format as Shopify Mobile, which is different from the format POS Now uses. This PR adds patterns to match POS Next against the new format, to ensure that builds of POS Now and POS Next are considered the same user agent from the perspective of anything using the BrowserSniffer.

I ensured that the new patterns accept either "Shopify POS Next" or "Shopify POS" as the app name, since POS Next is currently sending the former name, but will likely switch to the latter name once it ships. The BrowserSniffer will map both of these names to "Shopify POS".

This was run by the channels team in [this issue](https://github.com/Shopify/channels-data/issues/880), and it seems that this change will have no negative impact on their data.

[Corresponding POS Next issue](https://github.com/Shopify/pos-next/issues/467)