### PR TITLE
Add SameSite None Compatible check

### DIFF
--- a/lib/browser_sniffer.rb
+++ b/lib/browser_sniffer.rb
@@ -153,4 +153,42 @@ class BrowserSniffer
     end
     result
   end
+
+  def same_site_none_compatible?
+    return false unless user_agent
+
+    webkit_same_site_compatible? && same_site_recognized_browser?
+  end
+
+  def webkit_same_site_compatible?
+    return false unless os && os_version && browser
+
+    !(os == :ios && os_version.match(/^([0-9]|1[12])[\.\_]/)) &&
+       !(os == :mac && browser == :safari && os_version.match(/^10[\.\_]14/))
+  end
+
+  def same_site_recognized_browser?
+    return false unless major_browser_version
+
+    !(chromium_based? && major_browser_version >= 51 && major_browser_version <= 66) &&
+      !(uc_browser? && !uc_browser_version_at_least?(12, 13, 2))
+  end
+
+  def chromium_based?
+    browser_name ? browser_name.downcase.match(/chrom(e|ium)/) : false
+  end
+
+  def uc_browser?
+    user_agent ? user_agent.downcase.match(/uc\s?browser/) : false
+  end
+
+  def uc_browser_version_at_least?(major, minor, build)
+    return false unless browser_version
+    digits = browser_version.split('.').map(&:to_i)
+    return false unless digits.count >= 3
+
+    return digits[0] > major if digits[0] != major
+    return digits[1] > minor if digits[1] != minor
+    digits[2] >= build
+  end
 end

--- a/test/shopify_agents_test.rb
+++ b/test/shopify_agents_test.rb
@@ -674,4 +674,37 @@ describe "Shopify agents" do
       name: 'iOS',
     }), sniffer.os_info
   end
+
+  INCOMPATIBLE_USER_AGENTS = [
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 12_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko)"\
+      " GSA/87.0.279142407 Mobile/15E148 Safari/605.1",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/605.1.15 (KHTML, like Gecko)"\
+      " Version/12.1.2 Safari/605.1.15",
+    "Mozilla/5.0 (Linux; U; Android 7.0; en-US; SM-G935F Build/NRD90M) AppleWebKit/534.30 (KHTML, like Gecko) "\
+      "Version/4.0 UCBrowser/11.3.8.976 U3/0.8.0 Mobile Safari/534.30",
+  ]
+
+  INCOMPATIBLE_USER_AGENTS.each do |user_agent|
+    it "user agent #{user_agent} is correctly marked as incompatible" do
+      sniffer = BrowserSniffer.new(user_agent)
+
+      refute sniffer.same_site_none_compatible?
+    end
+  end
+
+  COMPATIBLE_USER_AGENTS = [
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117"\
+      " Safari/537.36",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:72.0) Gecko/20100101 Firefox/72.0",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.4"\
+      " Safari/605.1.15",
+  ]
+
+  COMPATIBLE_USER_AGENTS.each do |user_agent|
+    it "user agent #{user_agent} is correctly marked as compatible" do
+      sniffer = BrowserSniffer.new(user_agent)
+      
+      assert sniffer.same_site_none_compatible?
+    end
+  end
 end


### PR DESCRIPTION
Due to the release of Chrome 80 (where the [default for SameSite property for cookies is "Lax"](https://www.chromestatus.com/feature/5088147346030592) and not "None"), we have been checking the user agent to see if many browsers are [compatible](https://www.chromium.org/updates/same-site/incompatible-clients) with SameSite=None before setting the attribute. Since there is repeated code for the same check across Shopify (example: [shopify_app](https://github.com/Shopify/shopify_app/blob/master/lib/shopify_app/middleware/same_site_cookie_middleware.rb)), adding the check here is the best call.