### PR TITLE
Bump version to 1.2.0

### DIFF
--- a/lib/browser_sniffer/version.rb
+++ b/lib/browser_sniffer/version.rb
@@ -1,3 +1,3 @@
 class BrowserSniffer
-  VERSION = "1.1.3"
+  VERSION = "1.2.0"
 end


### PR DESCRIPTION
Minor update to `browser_sniffer` due to the introduction of the SameSite None incompatible check
https://github.com/Shopify/browser_sniffer/pull/25

Also includes changes from
https://github.com/Shopify/browser_sniffer/pull/23 and https://github.com/Shopify/browser_sniffer/pull/24

