### PR TITLE
Separate Shopify Android "debug"/"debug-push" flag from version number

### DIFF
--- a/lib/browser_sniffer/patterns.rb
+++ b/lib/browser_sniffer/patterns.rb
@@ -73,8 +73,8 @@ class BrowserSniffer
         %r{.*(Shopify POS Next|Shopify POS)\/(?:iOS)\/([\d\.]+) \((iPhone|iPad|iPod)}i
       ], [[:name, 'Shopify POS'], :version], [
         # Shopify Mobile for Android
-        %r{.*(Shopify Mobile)\/Android\/([\d\.]+(?: \(debug(?:|-push)\))?) \(Build (\d+) with API (\d+)}i
-      ], [[:name, 'Shopify Mobile'], :version, :build, :sdk_version], [
+        %r{.*(Shopify Mobile)\/Android\/([\d\.]+)(?: \((debug(?:|-push))\))? \(Build (\d+) with API (\d+)}i
+      ], [[:name, 'Shopify Mobile'], :version, :debug_mode, :build, :sdk_version], [
         # ShopifyFoundation shared library
         /^(ShopifyFoundation)/i,
       ], [:name], [

--- a/test/shopify_agents_test.rb
+++ b/test/shopify_agents_test.rb
@@ -155,6 +155,7 @@ describe "Shopify agents" do
     assert_equal ({
       name: 'Shopify Mobile',
       version: '5.4.4',
+      debug_mode: nil,
       build: '12005',
       sdk_version: '25',
     }), sniffer.browser_info
@@ -174,10 +175,11 @@ describe "Shopify agents" do
     "MobileMiddlewareSupported Mozilla/5.0 (Linux; Android 9; Android SDK built for x86 Build/PSR1.180720.075; wv) "\
     "AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/69.0.3497.100 Mobile Safari/537.36"
     sniffer = BrowserSniffer.new(user_agent)
-    
+
     assert_equal ({
       name: 'Shopify Mobile',
       version: '8.12.0',
+      debug_mode: nil,
       build: '12005',
       sdk_version: '28',
     }), sniffer.browser_info
@@ -203,7 +205,8 @@ describe "Shopify agents" do
 
     assert_equal ({
       name: 'Shopify Mobile',
-      version: '6.2.0 (debug)',
+      version: '6.2.0',
+      debug_mode: 'debug',
       build: '1',
       sdk_version: '25',
     }), sniffer.browser_info
@@ -557,7 +560,8 @@ describe "Shopify agents" do
 
     assert_equal ({
       name: 'Shopify Mobile',
-      version: '6.0.0 (debug)',
+      version: '6.0.0',
+      debug_mode: 'debug',
       build: '1',
       sdk_version: '25',
     }), sniffer.browser_info
@@ -580,7 +584,8 @@ describe "Shopify agents" do
 
     assert_equal ({
       name: 'Shopify Mobile',
-      version: '6.0.0 (debug-push)',
+      version: '6.0.0',
+      debug_mode: 'debug-push',
       build: '1',
       sdk_version: '25',
     }), sniffer.browser_info
@@ -703,7 +708,7 @@ describe "Shopify agents" do
   COMPATIBLE_USER_AGENTS.each do |user_agent|
     it "user agent #{user_agent} is correctly marked as compatible" do
       sniffer = BrowserSniffer.new(user_agent)
-      
+
       assert sniffer.same_site_none_compatible?
     end
   end


### PR DESCRIPTION
The regex for sniffing Shopify Mobile Android versions was including optional `"(debug)"` and `"(debug-push)"` strings as part of the version number. These strings are present in development builds of the Android app: e.g. the version number of the release build of 8.45.0 is `"8.45.0"`, while the development version is `"8.45.0 (debug)"`.

This prevented version numbers from debug builds from being parsed by `Gem::Version`, which thwarted certain Shopify version checks and led to some cumbersome string-splitting workarounds downstream in order to extract a consistent semantic version number from an arbitrary browser-sniffer result.

**This PR strips any debug string from the version number of Shopify Mobile Android, instead surfacing it in a separate `browser_info[:debug_mode]` key for contexts that do care about it.** The remaining version number is now consistent between development and release builds and should always be parsable by `Gem::Version`.

### Impact

This may affect event logging, insofar as Android debug build versions will no longer appear as distinct from release builds. However, since we weren't distinguishing debug from release builds for any of our *other* apps (including the iOS version of the same app), I don't imagine we're relying on this distinction for anything.