### PR TITLE
Bump version number to 1.2.1

### DIFF
--- a/lib/browser_sniffer/version.rb
+++ b/lib/browser_sniffer/version.rb
@@ -1,3 +1,3 @@
 class BrowserSniffer
-  VERSION = "1.2.0"
+  VERSION = "1.2.1"
 end


### PR DESCRIPTION
This PR just bumps the version number in preparation for making a new release, so that we can start using the fix from https://github.com/Shopify/browser_sniffer/pull/27 in Shopify core. That was the only change since version 1.2.0.