### PR TITLE
Add Chromium OS type in patterns

### DIFF
--- a/lib/browser_sniffer/patterns.rb
+++ b/lib/browser_sniffer/patterns.rb
@@ -332,7 +332,7 @@ class BrowserSniffer
         /(gnu)\s?([\w\.]+)*/i # GNU
       ], [:name, :version, [:type, :linux]], [
         /(cros)\s[\w]+\s([\w\.]+\w)/i # Chromium OS
-      ], [[:name, 'Chromium OS'], :version],[
+      ], [[:name, 'Chromium OS'], :version, [:type, :chromium_os]],[
         # Solaris
         /(sunos)\s?([\w\.]+\d)*/i # Solaris
       ], [[:name, 'Solaris'], :version], [

--- a/test/browser_sniffer_test.rb
+++ b/test/browser_sniffer_test.rb
@@ -544,7 +544,20 @@ class BrowserSnifferTest < Minitest::Test
       :os_version => nil,
       :browser => nil,
       :major_browser_version => nil
-    }
+    },
+    :chromiumos_chrome => {
+      :user_agent => "Mozilla/5.0 (X11; CrOS x86_64 10066.0.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.122 Safari/537.36",
+      :form_factor => :desktop,
+      :ios? => false,
+      :android? => false,
+      :desktop? => true,
+      :engine => :webkit,
+      :major_engine_version => 537,
+      :os => :chromium_os,
+      :os_version => '10066.0.0',
+      :browser => :chrome,
+      :major_browser_version => 81,
+    },
   }
 
   AGENTS.each do |agent, attributes|


### PR DESCRIPTION
### Fix https://github.com/Shopify/browser_sniffer/issues/29

Previously, there was no type defined for Chromium OS, so `BrowserSniffer#os` would return `nil`. This was a problem because the method `BrowserSniffer#same_site_none_compatible?` depends on this return value to determine whether `SameSite=none` is compatible (which it should be for the user agent defined in the issue).