### PR TITLE
bump version number to 1.3.0

### DIFF
--- a/lib/browser_sniffer/version.rb
+++ b/lib/browser_sniffer/version.rb
@@ -1,3 +1,3 @@
 class BrowserSniffer
-  VERSION = "1.2.2"
+  VERSION = "1.3.0"
 end


### PR DESCRIPTION
This PR bumps the version number in preparation for making a new release, so the fix from #34 can be used in Shopify core. That was the only change since version 1.2.2.