### PR TITLE
Add Patterns for POS React Native iOS

### DIFF
--- a/lib/browser_sniffer/patterns.rb
+++ b/lib/browser_sniffer/patterns.rb
@@ -60,8 +60,11 @@ class BrowserSniffer
         # Shopify POS for Android (Native App)
         %r{.*(\sPOS\s-).*\s([\d+\.]+)(\/\d*)*\s}i,
       ], [[:name, 'Shopify POS'], :version], [
-        # Shopify POS for Android (Native App) New Format
+        # Shopify POS for Android (React Native App)
         %r{(Shopify POS)\/([\d\.]+)[^\/]*\/(Android)\/(\d+)}i,
+      ], [[:name, 'Shopify POS'], :version], [
+        # Shopify POS for iOS (React Native App)
+        %r{(Shopify POS)\/([\d\.]+)[^\/]*\/(iOS)\/([\d\.]+)}i,
       ], [[:name, 'Shopify POS'], :version], [
         # Shopify POS for Android (SmartWebView)
         %r{.*(Shopify\sPOS)\s.*Android.*\s([\d+\.]+)(\/\d*)*\s}i,
@@ -174,6 +177,12 @@ class BrowserSniffer
         # Shopify POS Next for iPod touch
         %r{.*(?:Shopify POS Next|Shopify POS)/(?:iPhone\sOS|iOS)/[\d\.]+ \((iPod)([\d,]+)}i
       ], [[:type, :handheld], :model], [
+        # Shopify POS for iOS iPhone/iPod (React Native App)
+        %r{.*Shopify POS\/[\d\.]+[^\/]*\/(iOS)\/[\d\.]+\/Apple\/((iPhone|iPod)[^\/]*)\/}i,
+      ], [[:type, :handheld], :model], [
+        # Shopify POS for iOS iPad (React Native App)
+        %r{.*Shopify POS\/[\d\.]+[^\/]*\/(iOS)\/[\d\.]+\/Apple\/(iPad[^\/]*)\/}i,
+      ], [[:type, :tablet], :model], [
         # Shopify Ping for iPhone
         %r{.*Shopify Ping/(?:iPhone\sOS|iOS)/[\d\.]+ \((iPhone)([\d,]+)}i
       ], [[:type, :handheld], :model], [
@@ -297,6 +306,9 @@ class BrowserSniffer
         # Shopify POS Next for iPhone or iPad
         %r{.*(Shopify POS Next|Shopify POS)\/(?:iPhone\sOS|iOS)[\/\d\.]* \((iPhone|iPad|iPod).*\/([\d\.]+)\)}i
       ], [[:type, :ios], [:name, 'iOS'], :version], [
+        # Shopify POS for iOS (React Native App)
+        %r{.*Shopify POS\/[\d\.]+[^\/]*\/(iOS)\/([\d\.]+)\/(Apple)\/(iPhone|iPad|iPod)[^\/]*\/}i
+      ], [[:type, :ios], :version, [:name, 'iOS']], [
         # Shopify Ping for iOS
         %r{.*Shopify Ping\/(iOS)\/[\d\.]+ \(.*\/([\d\.]+)\)}i
       ], [[:type, :ios], :version, [:name, 'iOS']], [

--- a/test/shopify_agents_test.rb
+++ b/test/shopify_agents_test.rb
@@ -554,7 +554,7 @@ describe "Shopify agents" do
     assert_equal sniffer.os_info, sniffer_with_suffix.os_info
   end
 
-  it "Shopify POS on Android can be sniffed (Native App) New Format" do
+  it "Shopify POS on Android can be sniffed (React Native App)" do
     user_agent = "com.jadedpixel.pos Shopify POS/4.23.0/Android/12/google/Pixel 5/production MobileMiddlewareSupported"
     sniffer = BrowserSniffer.new(user_agent)
 
@@ -580,6 +580,69 @@ describe "Shopify agents" do
     assert_equal sniffer.browser_info, sniffer_with_suffix.browser_info
     assert_equal sniffer.device_info, sniffer_with_suffix.device_info
     assert_equal sniffer.os_info, sniffer_with_suffix.os_info
+  end
+
+  it "Shopify POS on iPhone can be sniffed (React Native App)" do
+    user_agent = "com.jadedpixel.pos Shopify POS/7.0.0/iOS/15.4/Apple/iPhone 11/production"
+    sniffer = BrowserSniffer.new(user_agent)
+
+    assert_equal ({
+      name: 'Shopify POS',
+      version: '7.0.0',
+    }), sniffer.browser_info
+
+    assert_equal ({
+      type: :handheld,
+      model: 'iPhone 11',
+    }), sniffer.device_info
+
+    assert_equal ({
+      type: :ios,
+      version: '15.4',
+      name: 'iOS',
+    }), sniffer.os_info
+  end
+
+  it "Shopify POS on iPad can be sniffed (React Native App)" do
+    user_agent = "com.jadedpixel.pos Shopify POS/7.0.0/iOS/15.4/Apple/iPad/production"
+    sniffer = BrowserSniffer.new(user_agent)
+
+    assert_equal ({
+      name: 'Shopify POS',
+      version: '7.0.0',
+    }), sniffer.browser_info
+
+    assert_equal ({
+      type: :tablet,
+      model: 'iPad',
+    }), sniffer.device_info
+
+    assert_equal ({
+      type: :ios,
+      version: '15.4',
+      name: 'iOS',
+    }), sniffer.os_info
+  end
+
+  it "Shopify POS on iPod Touch can be sniffed (React Native App)" do
+    user_agent = "com.jadedpixel.pos Shopify POS/7.0.0/iOS/15.4/Apple/iPod Touch/production"
+    sniffer = BrowserSniffer.new(user_agent)
+
+    assert_equal ({
+      name: 'Shopify POS',
+      version: '7.0.0',
+    }), sniffer.browser_info
+
+    assert_equal ({
+      type: :handheld,
+      model: 'iPod Touch',
+    }), sniffer.device_info
+
+    assert_equal ({
+      type: :ios,
+      version: '15.4',
+      name: 'iOS',
+    }), sniffer.os_info
   end
 
   it "Shopify Mobile in debug mode can be parsed" do


### PR DESCRIPTION
Resolves https://github.com/Shopify/pos-next-react-native/issues/13558

## Description of change
Some of Shopify's apps rely on this library to detect the POS app. Stocky in particular use this knowledge to redirect the user to a POS specific page if the Stocky app is being loaded within the POS app "browser".

Support for "sniffing" POS on RN for Android was added in November last year, however support for sniffing POS on RN for iOS is still missing.

## Why did you choose this approach?
* Followed [Android PR](https://github.com/Shopify/browser_sniffer/pull/36) as an example, as well as took inspiration from the developer [that introduced similar fix in a vendored version of this library](https://github.com/Shopify/stocky/commit/9b2604bbc5ab0f1e23ccd2da12ac8f0b1138d0ce)
* User agent format for RN is described in [this technical doc](https://docs.google.com/document/d/1Z8AxW8VO7XTa8qVU6Wtb_iviNWKy-cxG24T8AZuxIgY/edit)
  * `com.jadedpixel.pos Shopify POS/${appVersion}/${platform}/${platformVersion}/${brand}/${model}/${environment}`