### PR TITLE
Set Minimum Ruby Version to 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 1.9
   - 2.0
   - 2.1
   - 2.4

--- a/browser_sniffer.gemspec
+++ b/browser_sniffer.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 1.9.3"
+  spec.required_ruby_version = ">= 2.0.0"
 
   spec.metadata['allowed_push_host'] = 'https://rubygems.org'
 

--- a/lib/browser_sniffer/version.rb
+++ b/lib/browser_sniffer/version.rb
@@ -1,3 +1,3 @@
 class BrowserSniffer
-  VERSION = "1.5.0"
+  VERSION = "2.0.0"
 end


### PR DESCRIPTION
## Description of change
Bumps min version up. The min version for this gem was set 9 years ago on the initial commit and has non changed since then. Ruby 1.9 is also over a decade old.

## Why did you choose this approach?
Ruby 1.9 is causing me problems with migrating away from TravisCI to Github Actions (follow up PR). The path of least resistance in this case is to move away from an ancient version of Ruby.