### PR TITLE
Allow Manual Github Actions Workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: Ruby CI
 
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches: master


### PR DESCRIPTION
Originally `1.5.0` of this gem was not published because CI was in a poor state, so deploys (publishing) was disabled. `2.0.0` was released successfully, however I'd like to go back and release the earlier version as intended. Since CI is required to deploy, I need a way to trigger CI. Github Actions allows manually triggering workflows, as long as the event is listened to.