### PR TITLE
Add POS Go pattern

### DIFF
--- a/lib/browser_sniffer/patterns.rb
+++ b/lib/browser_sniffer/patterns.rb
@@ -46,7 +46,7 @@ class BrowserSniffer
     :browser => [
       [
         # Shopify POS Go
-        /WSC6X/i
+        /WSC6X|WTH1X/i
       ], [[:name, 'Shopify POS Go']],[
         # Shopify Mobile for iPhone or iPad
         %r{.*Shopify/\d+\s\((iPhone|iPad)\;\siOS\s[\d\.]+}i
@@ -173,7 +173,7 @@ class BrowserSniffer
     :device => [
       [
         # Shopify POS Go
-        /WSC6X/i
+        /WSC6X|WTH1X/i
       ], [[:type, :handheld], [:name, 'Shopify POS Go']],[
         # Shopify Mobile for iPhone
         %r{.*Shopify Mobile/(?:iPhone\sOS|iOS)/[\d\.]+ \((iPhone)([\d,]+)}i
@@ -302,7 +302,7 @@ class BrowserSniffer
     :os => [
       [
         # Shopify Retail OS on POS Go
-        /WSC6X/i
+        /WSC6X|WTH1X/i
       ], [[:name, 'Shopify Retail OS']],[
         # Shopify Mobile for iOS
         %r{.*Shopify/\d+\s\((?:iPhone|iPad)\;\s(iOS)\s([\d\.]+)}i

--- a/test/shopify_agents_test.rb
+++ b/test/shopify_agents_test.rb
@@ -2,8 +2,26 @@ require "test_helper"
 
 describe "Shopify agents" do
 
-  it "Shopify POS Go can be sniffed" do
+  it "Shopify POS Go can be sniffed with old model name" do
     user_agent = "Mozilla/5.0 (Linux; Android 10; ETNA/29/BBPOS/WSC6X) Chrome"
+    sniffer = BrowserSniffer.new(user_agent)
+
+    assert_equal ({
+      name: 'Shopify POS Go',
+    }), sniffer.browser_info
+
+    assert_equal ({
+      name: 'Shopify Retail OS',
+    }), sniffer.os_info
+
+    assert_equal ({
+      type: :handheld,
+      name: 'Shopify POS Go',
+    }), sniffer.device_info
+  end
+
+  it "Shopify POS Go can be sniffed with new model name" do
+    user_agent = "Mozilla/5.0 (Linux; Android 10; ETNA/29/BBPOS/WTH1X) Chrome"
     sniffer = BrowserSniffer.new(user_agent)
 
     assert_equal ({


### PR DESCRIPTION
Fixes shopify/boot-to-shopify#1509

## Description of change

Adding patterns to identify POS Go devices per [this ticket](https://github.com/Shopify/boot-to-shopify/issues/1509).

## Why did you choose this approach?

The browser sniffer uses the user agent to identify the browser, OS, and device.

The browser on POS Go uses a custom user agent that can be identified by the model name `WSC6X`. This model name has been used to identify user agent strings containing `WSC6X` as the browser on POS Go.

For more context, see [this discussion](https://github.com/Shopify/identity/issues/18540)

## What should reviewers focus on?

I'm open to suggestions about how things are named. Names will be returned as follows:

- Browser name: `Shopify POS Go`
- OS name: `Shopify Retail OS`
- Device name: `Shopify POS Go`

The browser name was chosen to make sure that it is easy to identify a login on a POS Go device from `https://accounts.shopify.com/accounts/.../security`. Logins are displayed here as "`Browser name` on `OS name`" (e.g., "Shopify POS Go on Shopify Retail OS"

## Before you merge

- [x] The changes covered by automated tests (e.g. unit, E2E)
