### PR TITLE
Add shopify mobile user agent pattern with build number

### DIFF
--- a/lib/browser_sniffer/patterns.rb
+++ b/lib/browser_sniffer/patterns.rb
@@ -322,6 +322,9 @@ class BrowserSniffer
         # Shopify Mobile for iPhone or iPad
         %r{.*(Shopify Mobile)\/(?:iPhone\sOS|iOS)[\/\d\.]* \((iPhone|iPad|iPod).*\/([\d\.]+)\)}i
       ], [[:type, :ios], [:name, 'iOS'], :version], [
+        # Shopify Mobile for iPhone or iPad with build number
+        %r{.*(Shopify Mobile)\/(?:iPhone\sOS|iOS)[\/\d\.]* \((iPhone|iPad|iPod).*\/([\d\.]+) - Build [\d]*\)}i
+      ], [[:type, :ios], [:name, 'iOS'], :version], [
         # Shopify POS Next for iPhone or iPad
         %r{.*(Shopify POS Next|Shopify POS)\/(?:iPhone\sOS|iOS)[\/\d\.]* \((iPhone|iPad|iPod).*\/([\d\.]+)\)}i
       ], [[:type, :ios], [:name, 'iOS'], :version], [

--- a/test/shopify_agents_test.rb
+++ b/test/shopify_agents_test.rb
@@ -79,6 +79,25 @@ describe "Shopify agents" do
       version: '12.0.0',
       name: 'iOS',
     }), sniffer.os_info
+
+    user_agent = "Shopify Mobile/iOS/9.108.0 (iPhone14,5 Simulator/com.shopify.Shopify/16.4 - Build 225)"
+    sniffer = BrowserSniffer.new(user_agent)
+
+    assert_equal ({
+      name: 'Shopify Mobile',
+      version: '9.108.0',
+    }), sniffer.browser_info
+
+    assert_equal ({
+      type: :handheld,
+      model: '14,5',
+    }), sniffer.device_info
+
+    assert_equal ({
+      type: :ios,
+      version: '16.4',
+      name: 'iOS',
+    }), sniffer.os_info
   end
 
   it "Shopify Mobile on iPod touch can be sniffed" do


### PR DESCRIPTION
Add the Shopify Mobile user agent patterns since the mobile app has added the build number on it.

iOS looks like: `Shopify Mobile/iOS/8.12.0 (iPad4,7/com.shopify.ShopifyInternal/12.0.0 - Build 225)`

Android looks like:  `Shopify Mobile/Android/9.108.0 (Build 1 with API 31 on Google sdk_gphone64_arm64)`