### PR TITLE
Fixes POS Go User Agent Detection

### DIFF
--- a/lib/browser_sniffer/patterns.rb
+++ b/lib/browser_sniffer/patterns.rb
@@ -46,7 +46,7 @@ class BrowserSniffer
     :browser => [
       [
         # Shopify POS Go
-        /WSC6X|WTH1X/i
+        /WSC6X|WTH11/i
       ], [[:name, 'Shopify POS Go']],[
         # Shopify Mobile for iPhone or iPad
         %r{.*Shopify/\d+\s\((iPhone|iPad)\;\siOS\s[\d\.]+}i
@@ -173,7 +173,7 @@ class BrowserSniffer
     :device => [
       [
         # Shopify POS Go
-        /WSC6X|WTH1X/i
+        /WSC6X|WTH11/i
       ], [[:type, :handheld], [:name, 'Shopify POS Go']],[
         # Shopify Mobile for iPhone
         %r{.*Shopify Mobile/(?:iPhone\sOS|iOS)/[\d\.]+ \((iPhone)([\d,]+)}i
@@ -302,7 +302,7 @@ class BrowserSniffer
     :os => [
       [
         # Shopify Retail OS on POS Go
-        /WSC6X|WTH1X/i
+        /WSC6X|WTH11/i
       ], [[:name, 'Shopify Retail OS']],[
         # Shopify Mobile for iOS
         %r{.*Shopify/\d+\s\((?:iPhone|iPad)\;\s(iOS)\s([\d\.]+)}i

--- a/test/shopify_agents_test.rb
+++ b/test/shopify_agents_test.rb
@@ -21,7 +21,7 @@ describe "Shopify agents" do
   end
 
   it "Shopify POS Go can be sniffed with new model name" do
-    user_agent = "Mozilla/5.0 (Linux; Android 10; ETNA/29/BBPOS/WTH1X) Chrome"
+    user_agent = "Mozilla/5.0 (Linux; Android 10; ETNA/29/BBPOS/WTH11) Chrome"
     sniffer = BrowserSniffer.new(user_agent)
 
     assert_equal ({


### PR DESCRIPTION
For Context:
> We updated Browser sniffer to identify POS Go a while ago here This seems incorrect because the current specd POS Go has model name of WTH11 instead of WTH1X as well the tests added in that PR don't seem to match up the the POS Go user agent at all. I'm not sure if this is causing any problems currently, but is something to be looked at.

There was a shift in POS Go model name some time ago, it was observed that the user agent was not updated in browser_sniffer. This aligns browser_sniffer to the current POS Go device model number.