### PR TITLE
Update CI Ruby versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,16 +14,10 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - 2.0
-          - 2.1
-          - 2.2
-          - 2.3
-          - 2.4
-          - 2.5
-          - 2.6
           - 2.7
           - 3.0
           - 3.1
+          - 3.2
           - jruby
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Some of the current Ruby versions are EOL. I had observed that CI was failing post merge. This brings Ruby versions in line with what is currently supported, see: https://www.ruby-lang.org/en/downloads/branches/