### PR TITLE
Add samsung user agent

### DIFF
--- a/lib/browser_sniffer/patterns.rb
+++ b/lib/browser_sniffer/patterns.rb
@@ -98,6 +98,9 @@ class BrowserSniffer
       ], [:name, :version, :major, [:type, :opera]], [
         /\s(opr)\/((\d+)?[\w\.]+)/i # Opera Webkit
       ], [[:name, 'Opera'], :version, :major, [:type, :opera]], [
+        /(SamsungBrowser)\/((\d+)?[\w\.-]+)/i, # Samsung Browser
+        %r{(SamsungBrowser)/((\d+)?[\w\.-]+)}i, # Samsung Browser
+      ], [:name, :version, :major, [:type, :samsung]], [
         # Mixed
         /(kindle)\/((\d+)?[\w\.]+)/i, # Kindle
         /(lunascape|maxthon|netfront|jasmine|blazer)[\/\s]?((\d+)?[\w\.]+)*/i, # Lunascape/Maxthon/Netfront/Jasmine/Blazer

--- a/test/browser_sniffer_test.rb
+++ b/test/browser_sniffer_test.rb
@@ -675,6 +675,23 @@ class BrowserSnifferTest < Minitest::Test
       :major_browser_version => 103,
       :in_app_browser => :instagram,
     },
+    :samsung_browser => {
+      :user_agent => "Mozilla/5.0 (Linux; Android 13; SAMSUNG SM-S918B) AppleWebKit/537.36 (KHTML, like Gecko) "\
+        "SamsungBrowser/23.0 Chrome/115.0.0.0 Mobile Safari/537.36",
+      :form_factor => :handheld,
+      :ios? => false,
+      :ie11? => false,
+      :ie11_actual? => false,
+      :android? => true,
+      :desktop? => false,
+      :engine => :webkit,
+      :major_engine_version => 537,
+      :os => :android,
+      :os_version => "13",
+      :browser => :samsung,
+      :major_browser_version => 23,
+      :in_app_browser => nil,
+    },
   }
 
   AGENTS.each do |agent, attributes|


### PR DESCRIPTION
Add the SamsungBrowser [user agent patterns](https://developer.samsung.com/internet/user-agent-string-format.html). Pattern looks like 

```rb
"Mozilla/5.0 (Linux; Android 13; SAMSUNG SM-S918B) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/23.0 Chrome/115.0.0.0 Mobile Safari/537.36"
"Mozilla/5.0 (Linux; Android 10; LYA-L29) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/23.0 Chrome/115.0.0.0 Mobile Safari/537.36"
"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/23.0 Chrome/115.0.0.0 Safari/537.36"
"Mozilla/5.0 (Linux; Android 8.1.0; Redmi 5 Plus) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/23.0 Chrome/115.0.0.0 Mobile Safari/537.36"
```

