### PR TITLE
Updates the minimum Ruby version to 3.0.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - 2.7
           - 3.0
           - 3.1
           - 3.2

--- a/browser_sniffer.gemspec
+++ b/browser_sniffer.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.0.0"
+  spec.required_ruby_version = ">= 3.0.0"
 
   spec.metadata['allowed_push_host'] = 'https://rubygems.org'
 


### PR DESCRIPTION
Ruby versions below 3.0.x are no longer supported and EOL'ed. This pushes the minimum Ruby version to 3.0.x.
https://www.ruby-lang.org/en/downloads/branches/ for more information.