### PR TITLE
remove references to master in favor of main for the default branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   pull_request:
   push:
-    branches: master
+    branches: main
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://github.com/Shopify/browser_sniffer/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/Shopify/browser_sniffer/actions/workflows/test.yml)
+[![Build Status](https://github.com/Shopify/browser_sniffer/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/Shopify/browser_sniffer/actions/workflows/test.yml)
 [![Gem Version](https://badge.fury.io/rb/browser_sniffer.png)](http://badge.fury.io/rb/browser_sniffer)
 
 # BrowserSniffer


### PR DESCRIPTION
This replaces all references to "master" as a default branch in favor of "main". This effort reflects a rename of the default branch to "main".