### PR TITLE
Yandex browser pattern fix

### DIFF
--- a/lib/browser_sniffer/patterns.rb
+++ b/lib/browser_sniffer/patterns.rb
@@ -117,7 +117,7 @@ class BrowserSniffer
         /(flock|rockmelt|midori|epiphany|silk|skyfire|ovibrowser|bolt)\/((\d+)?[\w\.-]+)/i # Chromium/Flock/RockMelt/Midori/Epiphany/Silk/Skyfire/Bolt
       ], [:name, :version, :major], [
         /(yabrowser)\/((\d+)?[\w\.]+)/i # Yandex
-      ], [[:name, 'Yandex'], :version, :major], [
+      ], [[:name, 'Yandex Browser'], :version, :major, [:type, :yandex]], [
         /(comodo_dragon)\/((\d+)?[\w\.]+)/i # Comodo Dragon
       ], [[:name, 'Comodo Dragon'], :version, :major], [
         /(chromium)\/((\d+)?[\w\.-]+)/i, # Chromium

--- a/test/browser_sniffer_test.rb
+++ b/test/browser_sniffer_test.rb
@@ -675,6 +675,20 @@ class BrowserSnifferTest < Minitest::Test
       :major_browser_version => 103,
       :in_app_browser => :instagram,
     },
+    :yandex_mac => {
+      :user_agent => "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 YaBrowser/24.4.5.506 Yowser/2.5 Safari/537.36",
+      :form_factor => :desktop,
+      :ios? => false,
+      :android? => false,
+      :desktop? => true,
+      :engine => :webkit,
+      :major_engine_version => 537,
+      :os => :mac,
+      :os_version => '10.15.7',
+      :browser => :yandex,
+      :major_browser_version => 24,
+      :in_app_browser => nil,
+    },
   }
 
   AGENTS.each do |agent, attributes|


### PR DESCRIPTION
### This PR fixes detection of `Yandex Browser`

Before this change `#browser` for User Agent `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.6367.770 YaBrowser/24.6.2.770 (beta) Yowser/2.5 Safari/537.36` was returning `nil`. Now it returns `:yandex`