### PR TITLE
Add support for Shopify CLI

### DIFF
--- a/lib/browser_sniffer/patterns.rb
+++ b/lib/browser_sniffer/patterns.rb
@@ -90,6 +90,9 @@ class BrowserSniffer
         # Shopify Ping iOS
         %r{.*(Shopify Ping)\/(?:iPhone\sOS|iOS)\/([\d\.]+) \((iPhone|iPad|iPod)}i
       ], [[:name, 'Shopify Ping'], :version], [
+        # Shopify CLI
+        %r{.*(Shopify CLI); v=([\d\.]+)}i 
+      ], [[:name, 'Shopify CLI'], :version], [
         # Presto based
         /(opera\smini)\/((\d+)?[\w\.-]+)/i, # Opera Mini
         /(opera\s(mobile|tab)).+:version\/((\d+)?[\w\.-]+)/i, # Opera Mobi/Tablet

--- a/test/shopify_agents_test.rb
+++ b/test/shopify_agents_test.rb
@@ -827,6 +827,16 @@ describe "Shopify agents" do
     }), sniffer.os_info
   end
 
+  it "Shopify CLI can be sniffed" do
+    user_agent = "Shopify CLI; v=3.59.3"
+    sniffer = BrowserSniffer.new(user_agent)
+
+    assert_equal ({
+      name: 'Shopify CLI',
+      version: '3.59.3',
+    }), sniffer.browser_info
+  end
+
   INCOMPATIBLE_USER_AGENTS = {
     'missing' => nil,
 


### PR DESCRIPTION
We want to add support to sniff the [Shopify CLI ](https://github.com/Shopify/cli/blob/cf78c34c0e259a8ed85ae0731f909d53e329f298/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts#L691). The userAgent follows the format;

>Shopify CLI; v=1.2.3


- Updated browser_info regex
- Updated tests