### PR TITLE
Support older Shopify CLI versions

### DIFF
--- a/lib/browser_sniffer/patterns.rb
+++ b/lib/browser_sniffer/patterns.rb
@@ -91,7 +91,7 @@ class BrowserSniffer
         %r{.*(Shopify Ping)\/(?:iPhone\sOS|iOS)\/([\d\.]+) \((iPhone|iPad|iPod)}i
       ], [[:name, 'Shopify Ping'], :version], [
         # Shopify CLI
-        %r{.*(Shopify CLI); v=([\d\.]+)}i 
+        %r{.*(Shopify CLI)(?:; v=([\d\.]+))?}i 
       ], [[:name, 'Shopify CLI'], :version], [
         # Presto based
         /(opera\smini)\/((\d+)?[\w\.-]+)/i, # Opera Mini

--- a/test/shopify_agents_test.rb
+++ b/test/shopify_agents_test.rb
@@ -837,6 +837,16 @@ describe "Shopify agents" do
     }), sniffer.browser_info
   end
 
+  it "Shopify CLI without version can be sniffed" do
+    user_agent = "Shopify CLI"
+    sniffer = BrowserSniffer.new(user_agent)
+
+    assert_equal ({
+      name: 'Shopify CLI',
+      version: nil,
+    }), sniffer.browser_info
+  end
+
   INCOMPATIBLE_USER_AGENTS = {
     'missing' => nil,
 


### PR DESCRIPTION
Newer versions of the CLI have a user agent with version, `Shopify CLI; v=1.2.3`. Older versions do not include the version and look like `Shopify CLI`.

This change makes the version number format optional